### PR TITLE
feat: add labels/metadata support to IP ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,10 +38,16 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
   `make dev-apply/destroy` for local Terraform testing against docker-compose
 - **Added `.golangci.yml`** — golangci-lint v2 config; CI lint step on every PR
 
+## Phase 3: Features
+
+- **Added labels/metadata on IP ranges** — new `labels JSON` column on `subnets` table
+  (migration `1773964800_add_labels_to_subnets`); API accepts and returns `labels` map on
+  `POST /ranges` and `GET /ranges/:id`; Terraform provider exposes `labels` attribute on
+  `ipam_ip_range` resource
+
 ## Planned changes (not yet implemented)
 
 See skill documentation for full roadmap:
-- Metadata/labels on IP ranges
 - `ipam_ip_range` data source for Terraform provider
 - Audit log endpoint
 - Provider registry migration to registry.opentofu.org

--- a/container/api.go
+++ b/container/api.go
@@ -40,11 +40,12 @@ type UpdateRoutingDomainRequest struct {
 }
 
 type RangeRequest struct {
-	Parent     string `json:"parent"`
-	Name       string `json:"name"`
-	Range_size int    `json:"range_size"`
-	Domain     string `json:"domain"`
-	Cidr       string `json:"cidr"`
+	Parent     string            `json:"parent"`
+	Name       string            `json:"name"`
+	Range_size int               `json:"range_size"`
+	Domain     string            `json:"domain"`
+	Cidr       string            `json:"cidr"`
+	Labels     map[string]string `json:"labels"`
 }
 
 func GetRanges(c *fiber.Ctx) error {
@@ -63,6 +64,7 @@ func GetRanges(c *fiber.Ctx) error {
 			"parent": ranges[i].Parent_id,
 			"name":   ranges[i].Name,
 			"cidr":   ranges[i].Cidr,
+			"labels": ranges[i].Labels,
 		})
 	}
 	return c.Status(200).JSON(results)
@@ -89,6 +91,7 @@ func GetRange(c *fiber.Ctx) error {
 		"parent": rang.Parent_id,
 		"name":   rang.Name,
 		"cidr":   rang.Cidr,
+		"labels": rang.Labels,
 	})
 }
 
@@ -197,7 +200,8 @@ func directInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDomain *Routi
 	id, err := CreateRangeInDb(tx, parent_id,
 		int(domain_id),
 		p.Name,
-		p.Cidr)
+		p.Cidr,
+		p.Labels)
 
 	if err != nil {
 		_ = tx.Rollback()
@@ -306,7 +310,7 @@ func findNewLeaseAndInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDoma
 	nextSubnet, _ := cidr.NextSubnet(subnet, int(range_size))
 	log.Printf("next subnet will be starting with %s", nextSubnet.IP.String())
 
-	id, err := CreateRangeInDb(tx, int64(parent.Subnet_id), routingDomain.Id, p.Name, fmt.Sprintf("%s/%d", subnet.IP.To4().String(), subnetOnes))
+	id, err := CreateRangeInDb(tx, int64(parent.Subnet_id), routingDomain.Id, p.Name, fmt.Sprintf("%s/%d", subnet.IP.To4().String(), subnetOnes), p.Labels)
 
 	if err != nil {
 		_ = tx.Rollback()

--- a/container/data_access.go
+++ b/container/data_access.go
@@ -1,4 +1,5 @@
 // Copyright 2021 Google LLC
+// Copyright 2026 Boozt Fashion AB (modifications)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -34,17 +36,37 @@ type RoutingDomain struct {
 }
 
 type Range struct {
-	Subnet_id         int    `db:"subnet_id"`
-	Parent_id         int    `db:"parent_id"`
-	Routing_domain_id int    `db:"routing_domain_id"`
-	Name              string `db:"name"`
-	Cidr              string `db:"cidr"`
+	Subnet_id         int               `db:"subnet_id"`
+	Parent_id         int               `db:"parent_id"`
+	Routing_domain_id int               `db:"routing_domain_id"`
+	Name              string            `db:"name"`
+	Cidr              string            `db:"cidr"`
+	Labels            map[string]string `db:"labels"`
+}
+
+func unmarshalLabels(s sql.NullString) map[string]string {
+	labels := map[string]string{}
+	if s.Valid && s.String != "" {
+		_ = json.Unmarshal([]byte(s.String), &labels)
+	}
+	return labels
+}
+
+func marshalLabels(labels map[string]string) interface{} {
+	if len(labels) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(labels)
+	if err != nil {
+		return nil
+	}
+	return string(b)
 }
 
 func GetRangesFromDB() ([]Range, error) {
 	var ranges []Range
 
-	rows, err := db.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr FROM subnets")
+	rows, err := db.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets")
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +75,9 @@ func GetRangesFromDB() ([]Range, error) {
 		var routing_domain_id int
 		tmp := pgtype.Int4{}
 		var name string
-		var cidr string
-		err := rows.Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidr)
+		var cidrVal string
+		var labelsJSON sql.NullString
+		err := rows.Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidrVal, &labelsJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +91,8 @@ func GetRangesFromDB() ([]Range, error) {
 			Parent_id:         parent_id,
 			Routing_domain_id: routing_domain_id,
 			Name:              name,
-			Cidr:              cidr,
+			Cidr:              cidrVal,
+			Labels:            unmarshalLabels(labelsJSON),
 		})
 	}
 	return ranges, nil
@@ -76,7 +100,7 @@ func GetRangesFromDB() ([]Range, error) {
 
 func GetRangesForParentFromDB(tx *sql.Tx, parent_id int64) ([]Range, error) {
 	var ranges []Range
-	rows, err := tx.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr FROM subnets WHERE parent_id = ? FOR UPDATE", parent_id)
+	rows, err := tx.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets WHERE parent_id = ? FOR UPDATE", parent_id)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +109,9 @@ func GetRangesForParentFromDB(tx *sql.Tx, parent_id int64) ([]Range, error) {
 		var routing_domain_id int
 		tmp := pgtype.Int4{}
 		var name string
-		var cidr string
-		err := rows.Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidr)
+		var cidrVal string
+		var labelsJSON sql.NullString
+		err := rows.Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidrVal, &labelsJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +125,8 @@ func GetRangesForParentFromDB(tx *sql.Tx, parent_id int64) ([]Range, error) {
 			Parent_id:         parent_id,
 			Routing_domain_id: routing_domain_id,
 			Name:              name,
-			Cidr:              cidr,
+			Cidr:              cidrVal,
+			Labels:            unmarshalLabels(labelsJSON),
 		})
 	}
 	return ranges, nil
@@ -111,10 +137,11 @@ func GetRangeFromDB(id int64) (*Range, error) {
 	var routing_domain_id int
 	tmp := pgtype.Int4{}
 	var name string
-	var cidr string
+	var cidrVal string
+	var labelsJSON sql.NullString
 
-	err := db.QueryRow("SELECT subnet_id, parent_id, routing_domain_id, name, cidr FROM subnets WHERE subnet_id = ?", id).Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidr)
-
+	err := db.QueryRow("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets WHERE subnet_id = ?", id).
+		Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidrVal, &labelsJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +155,8 @@ func GetRangeFromDB(id int64) (*Range, error) {
 		Parent_id:         parent_id,
 		Routing_domain_id: routing_domain_id,
 		Name:              name,
-		Cidr:              cidr,
+		Cidr:              cidrVal,
+		Labels:            unmarshalLabels(labelsJSON),
 	}, nil
 }
 
@@ -137,10 +165,11 @@ func GetRangeFromDBWithTx(tx *sql.Tx, id int64) (*Range, error) {
 	var routing_domain_id int
 	tmp := pgtype.Int4{}
 	var name string
-	var cidr string
+	var cidrVal string
+	var labelsJSON sql.NullString
 
-	err := tx.QueryRow("SELECT subnet_id, parent_id, routing_domain_id, name, cidr FROM subnets WHERE subnet_id = ? FOR UPDATE", id).Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidr)
-
+	err := tx.QueryRow("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets WHERE subnet_id = ? FOR UPDATE", id).
+		Scan(&subnet_id, &tmp, &routing_domain_id, &name, &cidrVal, &labelsJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +183,8 @@ func GetRangeFromDBWithTx(tx *sql.Tx, id int64) (*Range, error) {
 		Parent_id:         parent_id,
 		Routing_domain_id: routing_domain_id,
 		Name:              name,
-		Cidr:              cidr,
+		Cidr:              cidrVal,
+		Labels:            unmarshalLabels(labelsJSON),
 	}, nil
 }
 
@@ -162,9 +192,11 @@ func getRangeByCidrAndRoutingDomain(tx *sql.Tx, request_cidr string, routing_dom
 	var subnet_id int
 	tmp := pgtype.Int4{}
 	var name string
-	var cidr string
+	var cidrVal string
+	var labelsJSON sql.NullString
 
-	err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr FROM subnets WHERE cidr = ? and routing_domain_id = ? FOR UPDATE", request_cidr, routing_domain_id).Scan(&subnet_id, &tmp, &name, &cidr)
+	err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr, labels FROM subnets WHERE cidr = ? and routing_domain_id = ? FOR UPDATE", request_cidr, routing_domain_id).
+		Scan(&subnet_id, &tmp, &name, &cidrVal, &labelsJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +211,8 @@ func getRangeByCidrAndRoutingDomain(tx *sql.Tx, request_cidr string, routing_dom
 		Parent_id:         parent_id,
 		Routing_domain_id: routing_domain_id,
 		Name:              name,
-		Cidr:              cidr,
+		Cidr:              cidrVal,
+		Labels:            unmarshalLabels(labelsJSON),
 	}, nil
 }
 
@@ -187,15 +220,18 @@ func GetRangeByCidrFromDB(tx *sql.Tx, routing_domain_id int, cidr_request string
 	var subnet_id int
 	tmp := pgtype.Int4{}
 	var name string
-	var cidr string
+	var cidrVal string
+	var labelsJSON sql.NullString
 
 	if cidr_request != "" {
-		err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr FROM subnets WHERE cidr = ? and routing_domain_id = ? FOR UPDATE", cidr_request, routing_domain_id).Scan(&subnet_id, &tmp, &name, &cidr)
+		err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr, labels FROM subnets WHERE cidr = ? and routing_domain_id = ? FOR UPDATE", cidr_request, routing_domain_id).
+			Scan(&subnet_id, &tmp, &name, &cidrVal, &labelsJSON)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr FROM subnets WHERE routing_domain_id = ? LIMIT 1 FOR UPDATE", routing_domain_id).Scan(&subnet_id, &tmp, &name, &cidr)
+		err := tx.QueryRow("SELECT subnet_id, parent_id, name, cidr, labels FROM subnets WHERE routing_domain_id = ? LIMIT 1 FOR UPDATE", routing_domain_id).
+			Scan(&subnet_id, &tmp, &name, &cidrVal, &labelsJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +246,8 @@ func GetRangeByCidrFromDB(tx *sql.Tx, routing_domain_id int, cidr_request string
 		Parent_id:         parent_id,
 		Routing_domain_id: routing_domain_id,
 		Name:              name,
-		Cidr:              cidr,
+		Cidr:              cidrVal,
+		Labels:            unmarshalLabels(labelsJSON),
 	}, nil
 }
 
@@ -232,9 +269,10 @@ func DeleteRoutingDomainFromDB(id int64) error {
 	return nil
 }
 
-func CreateRangeInDb(tx *sql.Tx, parent_id int64, routing_domain_id int, name string, cidr string) (int64, error) {
+func CreateRangeInDb(tx *sql.Tx, parent_id int64, routing_domain_id int, name string, cidrVal string, labels map[string]string) (int64, error) {
+	labelsJSON := marshalLabels(labels)
 	if parent_id == -1 {
-		res, err := tx.Exec("INSERT INTO subnets (routing_domain_id, name, cidr) VALUES (?,?,?);", routing_domain_id, name, cidr)
+		res, err := tx.Exec("INSERT INTO subnets (routing_domain_id, name, cidr, labels) VALUES (?,?,?,?);", routing_domain_id, name, cidrVal, labelsJSON)
 		if err != nil {
 			return -1, err
 		}
@@ -244,7 +282,7 @@ func CreateRangeInDb(tx *sql.Tx, parent_id int64, routing_domain_id int, name st
 		}
 		return subnet_id, nil
 	} else {
-		res, err := tx.Exec("INSERT INTO subnets (parent_id, routing_domain_id, name, cidr) VALUES (?,?,?,?);", parent_id, routing_domain_id, name, cidr)
+		res, err := tx.Exec("INSERT INTO subnets (parent_id, routing_domain_id, name, cidr, labels) VALUES (?,?,?,?,?);", parent_id, routing_domain_id, name, cidrVal, labelsJSON)
 		if err != nil {
 			return -1, err
 		}

--- a/container/integration_test.go
+++ b/container/integration_test.go
@@ -327,6 +327,43 @@ func TestDeleteRange(t *testing.T) {
 	assert.Equal(t, 200, status)
 }
 
+func TestCreateRange_WithLabels(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, parentID := setupDomainAndParent(t, app)
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":       "gke-nodes-prod",
+		"range_size": 22,
+		"parent":     fmt.Sprintf("%d", parentID),
+		"domain":     fmt.Sprintf("%d", domainID),
+		"labels": map[string]string{
+			"env":     "prod",
+			"team":    "platform",
+			"purpose": "gke-nodes",
+		},
+	})
+	assert.Equal(t, 200, status)
+
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &created))
+	id := int(created["id"].(float64))
+
+	// Verify labels are returned on GET
+	status, body = doRequestWithStatus(app, "GET", fmt.Sprintf("/api/v1/ranges/%d", id), nil)
+	assert.Equal(t, 200, status)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	labels, ok := resp["labels"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "prod", labels["env"])
+	assert.Equal(t, "platform", labels["team"])
+	assert.Equal(t, "gke-nodes", labels["purpose"])
+}
+
 // --- Legacy route backward compat ---
 
 func TestLegacyRoutesStillWork(t *testing.T) {

--- a/container/migrations/1773964800_add_labels_to_subnets.down.sql
+++ b/container/migrations/1773964800_add_labels_to_subnets.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2026 Boozt Fashion AB
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE subnets DROP COLUMN labels;

--- a/container/migrations/1773964800_add_labels_to_subnets.up.sql
+++ b/container/migrations/1773964800_add_labels_to_subnets.up.sql
@@ -1,0 +1,15 @@
+-- Copyright 2026 Boozt Fashion AB
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE subnets ADD COLUMN labels JSON NULL;

--- a/examples/local-dev/main.tf
+++ b/examples/local-dev/main.tf
@@ -52,6 +52,10 @@ resource "ipam_ip_range" "gke_nodes" {
   range_size = 22
   parent     = ipam_ip_range.parent.cidr
   domain     = ipam_routing_domain.local.id
+  labels = {
+    env     = "local"
+    purpose = "gke-nodes"
+  }
 }
 
 output "gke_nodes_cidr" {

--- a/provider/ipam/resources/resource_ip_range.go
+++ b/provider/ipam/resources/resource_ip_range.go
@@ -63,6 +63,12 @@ func ResourceIpRange() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -73,30 +79,29 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	domain := d.Get("domain").(string)
 	cidr := d.Get("cidr").(string)
+	labels := d.Get("labels").(map[string]interface{})
 	url := fmt.Sprintf("%s/ranges", config.Url)
 	var postBody []byte
 	var err error
-	if parent == "" {
-		postBody, err = json.Marshal(map[string]interface{}{
-			"range_size": range_size,
-			"name":       name,
-			"domain":     domain,
-			"cidr":       cidr,
-		})
-		if err != nil {
-			return fmt.Errorf("failed marshalling json: %v", err)
+	body := map[string]interface{}{
+		"range_size": range_size,
+		"name":       name,
+		"domain":     domain,
+		"cidr":       cidr,
+	}
+	if parent != "" {
+		body["parent"] = parent
+	}
+	if len(labels) > 0 {
+		labelStrings := make(map[string]string, len(labels))
+		for k, v := range labels {
+			labelStrings[k] = v.(string)
 		}
-	} else {
-		postBody, err = json.Marshal(map[string]interface{}{
-			"range_size": range_size,
-			"name":       name,
-			"domain":     domain,
-			"parent":     parent,
-			"cidr":       cidr,
-		})
-		if err != nil {
-			return fmt.Errorf("failed marshalling json: %v", err)
-		}
+		body["labels"] = labelStrings
+	}
+	postBody, err = json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed marshalling json: %v", err)
 	}
 	fmt.Printf("%s", string(postBody))
 	responseBody := bytes.NewBuffer(postBody)
@@ -170,6 +175,15 @@ func resourceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		d.SetId(fmt.Sprintf("%d", int(response["id"].(float64))))
 		_ = d.Set("cidr", response["cidr"].(string))
+		if labelsRaw, ok := response["labels"]; ok && labelsRaw != nil {
+			if labelsMap, ok := labelsRaw.(map[string]interface{}); ok {
+				labels := make(map[string]string, len(labelsMap))
+				for k, v := range labelsMap {
+					labels[k] = fmt.Sprintf("%v", v)
+				}
+				_ = d.Set("labels", labels)
+			}
+		}
 		return nil
 	} else {
 		body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
   - Adds `labels JSON` column to `subnets` table via migration `1773964800_add_labels_to_subnets`
   - API accepts and returns `labels map[string]string` on `POST /ranges` and `GET /ranges/:id`
   - Terraform provider exposes `labels` attribute on `ipam_ip_range` resource
   - Integration test `TestCreateRange_WithLabels` verifies end-to-end label round-trip