### PR TITLE
feat: add ipam_ip_range data source and API improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,11 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
   (migration `1773964800_add_labels_to_subnets`); API accepts and returns `labels` map on
   `POST /ranges` and `GET /ranges/:id`; Terraform provider exposes `labels` attribute on
   `ipam_ip_range` resource
+- **Added `ipam_ip_range` data source** — look up an existing range by name without
+  allocating a new one; uses `GET /ranges?name=` filter added to the API
+- **Added `name` validation** — `POST /ranges` returns 400 if `name` is missing
+- **Added `labels` validation** — `POST /ranges` returns 400 if any label key or value is empty
+- **Expanded POST /ranges response** — now returns `id`, `name`, `cidr`, and `labels`
 
 ## Planned changes (not yet implemented)
 

--- a/container/api.go
+++ b/container/api.go
@@ -50,7 +50,7 @@ type RangeRequest struct {
 
 func GetRanges(c *fiber.Ctx) error {
 	var results []*fiber.Map
-	ranges, err := GetRangesFromDB()
+	ranges, err := GetRangesFromDB(c.Query("name"))
 	if err != nil {
 		return c.Status(503).JSON(&fiber.Map{
 			"success": false,
@@ -135,6 +135,23 @@ func CreateNewRange(c *fiber.Ctx) error {
 		})
 	}
 
+	if p.Name == "" {
+		_ = tx.Rollback()
+		return c.Status(400).JSON(&fiber.Map{
+			"success": false,
+			"message": "name is required",
+		})
+	}
+	for k, v := range p.Labels {
+		if k == "" || v == "" {
+			_ = tx.Rollback()
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": "label keys and values must not be empty",
+			})
+		}
+	}
+
 	var routingDomain *RoutingDomain
 	if p.Domain == "" {
 		routingDomain, err = GetDefaultRoutingDomainFromDB(tx)
@@ -217,8 +234,10 @@ func directInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDomain *Routi
 	}
 
 	return c.Status(200).JSON(&fiber.Map{
-		"id":   id,
-		"cidr": p.Cidr,
+		"id":     id,
+		"name":   p.Name,
+		"cidr":   p.Cidr,
+		"labels": p.Labels,
 	})
 }
 
@@ -325,9 +344,12 @@ func findNewLeaseAndInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDoma
 		log.Fatal(err)
 	}
 
+	allocatedCidr := fmt.Sprintf("%s/%d", subnet.IP.To4().String(), subnetOnes)
 	return c.Status(200).JSON(&fiber.Map{
-		"id":   id,
-		"cidr": fmt.Sprintf("%s/%d", subnet.IP.To4().String(), subnetOnes),
+		"id":     id,
+		"name":   p.Name,
+		"cidr":   allocatedCidr,
+		"labels": p.Labels,
 	})
 }
 

--- a/container/api.go
+++ b/container/api.go
@@ -142,12 +142,33 @@ func CreateNewRange(c *fiber.Ctx) error {
 			"message": "name is required",
 		})
 	}
+	if len(p.Name) > 255 {
+		_ = tx.Rollback()
+		return c.Status(400).JSON(&fiber.Map{
+			"success": false,
+			"message": "name must not exceed 255 characters",
+		})
+	}
 	for k, v := range p.Labels {
 		if k == "" || v == "" {
 			_ = tx.Rollback()
 			return c.Status(400).JSON(&fiber.Map{
 				"success": false,
 				"message": "label keys and values must not be empty",
+			})
+		}
+		if len(k) > 63 {
+			_ = tx.Rollback()
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": fmt.Sprintf("label key %q must not exceed 63 characters", k),
+			})
+		}
+		if len(v) > 255 {
+			_ = tx.Rollback()
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": fmt.Sprintf("label value for key %q must not exceed 255 characters", k),
 			})
 		}
 	}

--- a/container/data_access.go
+++ b/container/data_access.go
@@ -63,10 +63,18 @@ func marshalLabels(labels map[string]string) interface{} {
 	return string(b)
 }
 
-func GetRangesFromDB() ([]Range, error) {
+func GetRangesFromDB(nameFilter string) ([]Range, error) {
 	var ranges []Range
 
-	rows, err := db.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets")
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if nameFilter != "" {
+		rows, err = db.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets WHERE name = ?", nameFilter)
+	} else {
+		rows, err = db.Query("SELECT subnet_id, parent_id, routing_domain_id, name, cidr, labels FROM subnets")
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/container/integration_test.go
+++ b/container/integration_test.go
@@ -406,6 +406,58 @@ func TestCreateRange_NameRequired(t *testing.T) {
 	assert.Equal(t, 400, status)
 }
 
+func TestCreateRange_NameTooLong(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   string(make([]byte, 256)),
+		"cidr":   "10.21.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	assert.Equal(t, 400, status)
+	assert.Contains(t, string(body), "255")
+}
+
+func TestCreateRange_LabelKeyTooLong(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, _ := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "valid-name",
+		"cidr":   "10.22.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+		"labels": map[string]string{
+			string(make([]byte, 64)): "value",
+		},
+	})
+	assert.Equal(t, 400, status)
+}
+
+func TestCreateRange_LabelValueTooLong(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, _ := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "valid-name",
+		"cidr":   "10.23.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+		"labels": map[string]string{
+			"key": string(make([]byte, 256)),
+		},
+	})
+	assert.Equal(t, 400, status)
+}
+
 // --- Legacy route backward compat ---
 
 func TestLegacyRoutesStillWork(t *testing.T) {

--- a/container/integration_test.go
+++ b/container/integration_test.go
@@ -364,6 +364,48 @@ func TestCreateRange_WithLabels(t *testing.T) {
 	assert.Equal(t, "gke-nodes", labels["purpose"])
 }
 
+func TestGetRanges_FilterByName(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "alpha",
+		"cidr":   "10.10.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "beta",
+		"cidr":   "10.11.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+
+	status, body := doRequestWithStatus(app, "GET", "/api/v1/ranges?name=alpha", nil)
+	assert.Equal(t, 200, status)
+
+	var resp []map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "alpha", resp[0]["name"])
+	assert.Equal(t, "10.10.0.0/24", resp[0]["cidr"])
+}
+
+func TestCreateRange_NameRequired(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := newApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, _ := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"cidr":   "10.20.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	assert.Equal(t, 400, status)
+}
+
 // --- Legacy route backward compat ---
 
 func TestLegacyRoutesStillWork(t *testing.T) {

--- a/examples/local-dev/main.tf
+++ b/examples/local-dev/main.tf
@@ -58,6 +58,14 @@ resource "ipam_ip_range" "gke_nodes" {
   }
 }
 
+data "ipam_ip_range" "gke_nodes_lookup" {
+  name = ipam_ip_range.gke_nodes.name
+}
+
 output "gke_nodes_cidr" {
   value = ipam_ip_range.gke_nodes.cidr
+}
+
+output "gke_nodes_cidr_via_datasource" {
+  value = data.ipam_ip_range.gke_nodes_lookup.cidr
 }

--- a/provider/ipam/provider.go
+++ b/provider/ipam/provider.go
@@ -39,8 +39,10 @@ func Provider() *schema.Provider {
 			"ipam_ip_range":       resources.ResourceIpRange(),
 			"ipam_routing_domain": resources.ResourceRoutingDomain(),
 		},
-		DataSourcesMap: map[string]*schema.Resource{},
-		ConfigureFunc:  providerConfigure,
+		DataSourcesMap: map[string]*schema.Resource{
+			"ipam_ip_range": resources.DataSourceIpRange(),
+		},
+		ConfigureFunc: providerConfigure,
 	}
 }
 

--- a/provider/ipam/resources/data_source_ip_range.go
+++ b/provider/ipam/resources/data_source_ip_range.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Boozt Fashion AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/boozt-platform/ipam-autopilot/provider/ipam/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceIpRange() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	cfg := meta.(config.Config)
+	name := d.Get("name").(string)
+
+	url := fmt.Sprintf("%s/ranges?name=%s", cfg.Url, name)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed creating request: %v", err)
+	}
+	accessToken, err := getIdentityToken()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve access token: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed querying ranges: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to read response: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed querying ranges status_code=%d, body=%s", resp.StatusCode, string(body))
+	}
+
+	var results []map[string]interface{}
+	if err := json.Unmarshal(body, &results); err != nil {
+		return fmt.Errorf("unable to unmarshal response: %v", err)
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("no ip range found with name %q", name)
+	}
+
+	match := results[0]
+	d.SetId(fmt.Sprintf("%d", int(match["id"].(float64))))
+	_ = d.Set("cidr", match["cidr"].(string))
+
+	if labelsRaw, ok := match["labels"]; ok && labelsRaw != nil {
+		if labelsMap, ok := labelsRaw.(map[string]interface{}); ok {
+			labels := make(map[string]string, len(labelsMap))
+			for k, v := range labelsMap {
+				labels[k] = fmt.Sprintf("%v", v)
+			}
+			_ = d.Set("labels", labels)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
  - New `data "ipam_ip_range"` Terraform data source - look up an existing range by name without allocating a new one
  - `GET /ranges?name=` filter added to API for name-based lookup
  - `POST /ranges` now validates that `name` is required and label keys/values are non-empty
  - `POST /ranges` response expanded to include `name` and `labels` alongside `id` and `cidr`
  - add max length validation for name (255) and label keys (63) / values (255)