### PR TITLE
feat: bulk import endpoint, IPAM_ env prefix, CAI + import docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,27 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - **Added bulk import workflow documentation** — step-by-step guide for adopting an
   existing VPC into IPAM management including `terraform import` steps
 
+## Phase 6: CAI integration refactor
+
+- **Replaced live CAI API call with DB-backed cache** — new `cai_subnets` table
+  (migration `1773939600_create_cai_subnets_table`); allocation reads from DB instead of
+  calling Cloud Asset Inventory on every `POST /ranges`; eliminates ~3000 subnet round-trip
+  on each auto-allocation
+- **Added startup CAI sync + background loop** — on startup (when `IPAM_CAI_ORG_ID` is set)
+  the server runs an initial blocking sync then starts a background goroutine that re-syncs
+  on `IPAM_CAI_SYNC_INTERVAL` (default `5m`); no external scheduler needed
+- **Sync is chunked and transactional** — upserts in batches of 200 per transaction; a
+  failed chunk is retried on the next sync cycle; stale entries (subnets deleted in GCP) are
+  removed after each sync
+- **Fixed `log.Fatal` in CAI iterator** — a CAI API error during iteration now returns an
+  error instead of crashing the server process
+- **Fixed VPC name matching** — routing domains may now store the short VPC name (e.g.
+  `my-vpc`) or the full resource URL; both forms match correctly against CAI network URLs
+- **Added `IPAM_CAI_SYNC_INTERVAL`** — configurable sync interval (Go duration string,
+  default `5m`)
+- **Added CAI integration tests** — mock-free: tests seed `cai_subnets` directly and verify
+  allocation avoids seeded CIDRs; covers short-name matching and VPC isolation
+
 ## Planned changes (not yet implemented)
 
 See skill documentation for full roadmap:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,15 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
   (`domains_test.go`, `ranges_test.go`, `audit_log_test.go`, `legacy_test.go`, `helpers_test.go`);
   unit tests for subnet logic moved to `container/server/subnet_test.go`
 
+## Phase 5: Bulk import
+
+- **Added `POST /api/v1/ranges/import`** — import pre-existing CIDRs into IPAM without
+  auto-allocation; accepts an array of `{ name, cidr, domain?, parent?, labels? }` items;
+  idempotent: ranges already present in the same domain are silently skipped; returns
+  `{ imported, skipped, errors }` summary; each imported range is written to the audit log;
+  use case: register manually-assigned subnets before enabling IPAM management, then
+  `terraform import` them into Terraform state
+
 ## Planned changes (not yet implemented)
 
 See skill documentation for full roadmap:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,7 +64,7 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
   (`domains_test.go`, `ranges_test.go`, `audit_log_test.go`, `legacy_test.go`, `helpers_test.go`);
   unit tests for subnet logic moved to `container/server/subnet_test.go`
 
-## Phase 5: Bulk import
+## Phase 5: Bulk import + env variable consistency
 
 - **Added `POST /api/v1/ranges/import`** — import pre-existing CIDRs into IPAM without
   auto-allocation; accepts an array of `{ name, cidr, domain?, parent?, labels? }` items;
@@ -72,6 +72,16 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
   `{ imported, skipped, errors }` summary; each imported range is written to the audit log;
   use case: register manually-assigned subnets before enabling IPAM management, then
   `terraform import` them into Terraform state
+- **Added `IPAM_DISABLE_BULK_IMPORT`** — set `TRUE` to disable the import endpoint (e.g. in
+  production environments where arbitrary CIDR registration is undesirable)
+- **Renamed all env variables to use `IPAM_` prefix** — `DATABASE_USER` →
+  `IPAM_DATABASE_USER`, `CAI_ORG_ID` → `IPAM_CAI_ORG_ID`, `GCP_IDENTITY_TOKEN` →
+  `IPAM_IDENTITY_TOKEN`, etc.; `OTEL_EXPORTER_OTLP_ENDPOINT` kept as-is (OpenTelemetry
+  standard); full list in README
+- **Added CAI integration documentation** — explains VPC scoping per routing domain and
+  how CAI prevents collision with subnets not registered in IPAM
+- **Added bulk import workflow documentation** — step-by-step guide for adopting an
+  existing VPC into IPAM management including `terraform import` steps
 
 ## Planned changes (not yet implemented)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ All environment variables are prefixed with `IPAM_`, except OpenTelemetry standa
 | Variable | Default | Description |
 |---|---|---|
 | `IPAM_CAI_ORG_ID` | | GCP organisation ID for Cloud Asset Inventory integration (see [CAI integration](#cloud-asset-inventory-integration)) |
-| `IPAM_CAI_SYNC_INTERVAL` | `5m` | How often to re-sync CAI subnets in the background (Go duration, e.g. `5m`, `1h`) |
+| `IPAM_CAI_DB_SYNC` | `FALSE` | Set `TRUE` to enable DB-backed CAI cache with background sync; default queries CAI live on each allocation |
+| `IPAM_CAI_SYNC_INTERVAL` | `5m` | Sync interval when `IPAM_CAI_DB_SYNC=TRUE` (Go duration, e.g. `5m`, `1h`) |
 | `IPAM_DISABLE_BULK_IMPORT` | `FALSE` | Set `TRUE` to disable `POST /api/v1/ranges/import` |
 | `IPAM_STORAGE_BUCKET` | | GCS bucket name for the legacy built-in provider registry |
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,41 @@ make dev-destroy         # terraform destroy local dev resources
 
 ### Environment variables
 
+All environment variables are prefixed with `IPAM_`, except OpenTelemetry standard variables.
+
+**Database**
+
 | Variable | Default | Description |
 |---|---|---|
-| `DATABASE_USER` | | MySQL username |
-| `DATABASE_PASSWORD` | | MySQL password |
-| `DATABASE_HOST` | | MySQL host:port |
-| `DATABASE_NAME` | | MySQL database name |
-| `DATABASE_NET` | `tcp` | MySQL network |
-| `DISABLE_DATABASE_MIGRATION` | `FALSE` | Set `TRUE` to skip auto-migration on startup |
-| `LOG_FORMAT` | `json` | Set `text` for human-readable logs |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | | OTLP gRPC endpoint for tracing (e.g. `jaeger:4317`) |
-| `PORT` | `8080` | HTTP listen port |
+| `IPAM_DATABASE_USER` | | MySQL username |
+| `IPAM_DATABASE_PASSWORD` | | MySQL password |
+| `IPAM_DATABASE_HOST` | | MySQL `host:port` |
+| `IPAM_DATABASE_NAME` | | MySQL database name |
+| `IPAM_DATABASE_NET` | `tcp` | MySQL network type |
+| `IPAM_DISABLE_DATABASE_MIGRATION` | `FALSE` | Set `TRUE` to skip auto-migration on startup |
+
+**Server**
+
+| Variable | Default | Description |
+|---|---|---|
+| `IPAM_PORT` | `8080` | HTTP listen port |
+| `IPAM_LOG_FORMAT` | `json` | Set `text` for human-readable logs |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | | OTLP gRPC endpoint for tracing (e.g. `jaeger:4317`) — standard OpenTelemetry variable |
+
+**Features**
+
+| Variable | Default | Description |
+|---|---|---|
+| `IPAM_CAI_ORG_ID` | | GCP organisation ID for Cloud Asset Inventory integration (see [CAI integration](#cloud-asset-inventory-integration)) |
+| `IPAM_DISABLE_BULK_IMPORT` | `FALSE` | Set `TRUE` to disable `POST /api/v1/ranges/import` |
+| `IPAM_STORAGE_BUCKET` | | GCS bucket name for the legacy built-in provider registry |
+
+**Terraform provider**
+
+| Variable | Default | Description |
+|---|---|---|
+| `IPAM_URL` | | IPAM API base URL (alternative to `url` in provider config) |
+| `IPAM_IDENTITY_TOKEN` | | GCP identity token for authenticating against Cloud Run; if unset, Application Default Credentials are used automatically |
 
 ---
 
@@ -63,19 +87,138 @@ make dev-destroy         # terraform destroy local dev resources
 All IPAM endpoints are available under `/api/v1`:
 
 ```
-POST   /api/v1/ranges
-GET    /api/v1/ranges
-GET    /api/v1/ranges/:id
-DELETE /api/v1/ranges/:id
+POST   /api/v1/ranges              allocate a new IP range (auto or direct CIDR)
+GET    /api/v1/ranges              list all ranges; optional ?name= filter
+GET    /api/v1/ranges/:id          get a single range
+DELETE /api/v1/ranges/:id          release a range
+POST   /api/v1/ranges/import       bulk-import pre-existing CIDRs (idempotent)
 
-POST   /api/v1/domains
-GET    /api/v1/domains
-GET    /api/v1/domains/:id
-PUT    /api/v1/domains/:id
-DELETE /api/v1/domains/:id
+POST   /api/v1/domains             create a routing domain
+GET    /api/v1/domains             list all routing domains
+GET    /api/v1/domains/:id         get a single routing domain
+PUT    /api/v1/domains/:id         update a routing domain
+DELETE /api/v1/domains/:id         delete a routing domain
+
+GET    /api/v1/audit?limit=N       last N audit log events (default 100, max 1000)
 ```
 
 Legacy paths (`/ranges`, `/domains`) are kept for Terraform provider backward compatibility.
+
+---
+
+## Cloud Asset Inventory integration
+
+When `IPAM_CAI_ORG_ID` is set, IPAM Autopilot queries [Cloud Asset Inventory](https://cloud.google.com/asset-inventory) during auto-allocation (`POST /ranges` with `range_size`) to discover existing VPC subnets across your GCP organisation.
+
+Discovered subnets are merged with IPAM DB allocations before the collision avoidance algorithm runs. This prevents double-allocation even for subnets that exist in GCP but were never registered in IPAM (for example, subnets created manually or outside of Terraform).
+
+**VPC scoping** — Each routing domain has an optional list of VPCs. When `IPAM_CAI_ORG_ID` is set, only subnets belonging to the domain's VPCs are considered. This means IPAM is safe to use across multiple independent VPCs: allocating a `/22` for `prod-vpc` will not be blocked by subnets in `staging-vpc` if they are in separate routing domains.
+
+**Required IAM** — The Cloud Run service account needs `roles/cloudasset.viewer` at the organisation level.
+
+---
+
+## Bulk import
+
+Use `POST /api/v1/ranges/import` to register pre-existing CIDRs in IPAM without triggering auto-allocation. This is the recommended first step when adopting IPAM for a VPC that already has manually-assigned subnets.
+
+### When to use
+
+- Migrating an existing VPC into IPAM management
+- Registering subnets that were created outside of Terraform so that future auto-allocations do not overlap with them
+- The endpoint is a complement to CAI integration: CAI prevents overlaps at allocation time, while bulk import makes subnets visible in IPAM for `terraform import` and audit purposes
+
+### Request
+
+`POST /api/v1/ranges/import` accepts a JSON array:
+
+```json
+[
+  {
+    "name":   "gke-nodes",
+    "cidr":   "10.1.0.0/22",
+    "domain": "1",
+    "labels": { "env": "prod", "purpose": "gke-nodes" }
+  },
+  {
+    "name":   "gke-pods",
+    "cidr":   "10.2.0.0/16",
+    "domain": "1"
+  }
+]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Range name (max 255 characters) |
+| `cidr` | yes | CIDR block to register (e.g. `10.1.0.0/22`) |
+| `domain` | no | Routing domain ID; defaults to the first domain |
+| `parent` | no | Parent range ID |
+| `labels` | no | Key/value metadata (key ≤ 63 chars, value ≤ 255 chars) |
+
+The endpoint is **idempotent**: ranges with the same CIDR already present in the same domain are silently skipped. Each imported range is written to the audit log.
+
+### Response
+
+```json
+{ "imported": 2, "skipped": 0, "errors": [] }
+```
+
+### Workflow: adopting an existing VPC
+
+1. **List existing subnets** in the VPC:
+
+   ```bash
+   gcloud compute networks subnets list \
+     --filter="network=projects/MY_PROJECT/global/networks/MY_VPC" \
+     --format="value(name,ipCidrRange)"
+   ```
+
+2. **Register them in IPAM**:
+
+   ```bash
+   curl -X POST https://YOUR_IPAM_URL/api/v1/ranges/import \
+     -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
+     -H "Content-Type: application/json" \
+     -d '[
+       {"name": "gke-nodes", "cidr": "10.1.0.0/22", "domain": "1"},
+       {"name": "gke-pods",  "cidr": "10.2.0.0/16", "domain": "1"}
+     ]'
+   ```
+
+3. **Write Terraform resources** for each imported range:
+
+   ```hcl
+   resource "ipam_ip_range" "gke_nodes" {
+     name   = "gke-nodes"
+     cidr   = "10.1.0.0/22"
+     domain = "1"
+   }
+
+   resource "ipam_ip_range" "gke_pods" {
+     name   = "gke-pods"
+     cidr   = "10.2.0.0/16"
+     domain = "1"
+   }
+   ```
+
+4. **Import into Terraform state** — get the range IDs from the import response or `GET /api/v1/ranges?name=gke-nodes`:
+
+   ```bash
+   terraform import ipam_ip_range.gke_nodes 42
+   terraform import ipam_ip_range.gke_pods  43
+   terraform plan   # should show no changes
+   ```
+
+### Security
+
+To disable the import endpoint in environments where arbitrary CIDR registration is undesirable (e.g. production), set:
+
+```bash
+IPAM_DISABLE_BULK_IMPORT=TRUE
+```
+
+When disabled, `POST /api/v1/ranges/import` returns `404`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,28 @@ Legacy paths (`/ranges`, `/domains`) are kept for Terraform provider backward co
 
 ## Cloud Asset Inventory integration
 
-When `IPAM_CAI_ORG_ID` is set, IPAM Autopilot queries [Cloud Asset Inventory](https://cloud.google.com/asset-inventory) during auto-allocation (`POST /ranges` with `range_size`) to discover existing VPC subnets across your GCP organisation.
+When `IPAM_CAI_ORG_ID` is set, IPAM Autopilot uses [Cloud Asset Inventory](https://cloud.google.com/asset-inventory) to discover existing VPC subnets across your GCP organisation and merge them with IPAM DB allocations before the collision avoidance algorithm runs. This prevents double-allocation even for subnets that exist in GCP but were never registered in IPAM.
 
-Discovered subnets are merged with IPAM DB allocations before the collision avoidance algorithm runs. This prevents double-allocation even for subnets that exist in GCP but were never registered in IPAM (for example, subnets created manually or outside of Terraform).
+**VPC scoping** — Each routing domain has an optional list of VPCs. Only subnets belonging to the domain's VPCs are considered. This means IPAM is safe to use across multiple independent VPCs: allocating a `/22` for `prod-vpc` will not be blocked by subnets in `staging-vpc` if they are in separate routing domains.
 
-**VPC scoping** — Each routing domain has an optional list of VPCs. When `IPAM_CAI_ORG_ID` is set, only subnets belonging to the domain's VPCs are considered. This means IPAM is safe to use across multiple independent VPCs: allocating a `/22` for `prod-vpc` will not be blocked by subnets in `staging-vpc` if they are in separate routing domains.
+**VPC name format** — The VPC list in a routing domain accepts both full resource URLs and short names:
+
+```
+# Full URL (as returned by gcloud)
+https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-vpc
+
+# Short name — simpler, works the same way
+my-vpc
+```
+
+**Two modes**
+
+| Mode | Config | Behaviour |
+|---|---|---|
+| Live (default) | `IPAM_CAI_ORG_ID` only | CAI API is queried on every `POST /ranges` with `range_size`; always up to date, adds latency per allocation |
+| DB sync | `IPAM_CAI_ORG_ID` + `IPAM_CAI_DB_SYNC=TRUE` | Subnets are synced into a local `cai_subnets` table on startup and refreshed every `IPAM_CAI_SYNC_INTERVAL` (default `5m`) in the background; allocations read from DB — fast, no per-request CAI latency |
+
+Use **DB sync mode** when you have many allocations per minute or want to reduce CAI API calls. Use **live mode** when you need guaranteed up-to-date collision avoidance and allocation frequency is low.
 
 **Required IAM** — The Cloud Run service account needs `roles/cloudasset.viewer` at the organisation level.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All environment variables are prefixed with `IPAM_`, except OpenTelemetry standa
 | Variable | Default | Description |
 |---|---|---|
 | `IPAM_CAI_ORG_ID` | | GCP organisation ID for Cloud Asset Inventory integration (see [CAI integration](#cloud-asset-inventory-integration)) |
+| `IPAM_CAI_SYNC_INTERVAL` | `5m` | How often to re-sync CAI subnets in the background (Go duration, e.g. `5m`, `1h`) |
 | `IPAM_DISABLE_BULK_IMPORT` | `FALSE` | Set `TRUE` to disable `POST /api/v1/ranges/import` |
 | `IPAM_STORAGE_BUCKET` | | GCS bucket name for the legacy built-in provider registry |
 

--- a/container/main.go
+++ b/container/main.go
@@ -17,12 +17,12 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
-
-	"database/sql"
+	"time"
 
 	"github.com/boozt-platform/ipam-autopilot/container/server"
 	"github.com/go-sql-driver/mysql"
@@ -68,6 +68,21 @@ func main() {
 	}
 
 	app := server.NewApp(db)
+
+	if orgID := os.Getenv("IPAM_CAI_ORG_ID"); orgID != "" {
+		interval := 5 * time.Minute
+		if raw := os.Getenv("IPAM_CAI_SYNC_INTERVAL"); raw != "" {
+			if d, err := time.ParseDuration(raw); err == nil {
+				interval = d
+			} else {
+				slog.Warn("invalid IPAM_CAI_SYNC_INTERVAL, using default", "value", raw, "default", interval)
+			}
+		}
+		if err := server.StartCAISyncLoop(ctx, orgID, interval); err != nil {
+			slog.Error("CAI sync failed on startup", "error", err)
+			os.Exit(1)
+		}
+	}
 
 	port := int64(8080)
 	if os.Getenv("IPAM_PORT") != "" {

--- a/container/main.go
+++ b/container/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	app := server.NewApp(db)
 
-	if orgID := os.Getenv("IPAM_CAI_ORG_ID"); orgID != "" {
+	if orgID := os.Getenv("IPAM_CAI_ORG_ID"); orgID != "" && os.Getenv("IPAM_CAI_DB_SYNC") == "TRUE" {
 		interval := 5 * time.Minute
 		if raw := os.Getenv("IPAM_CAI_SYNC_INTERVAL"); raw != "" {
 			if d, err := time.ParseDuration(raw); err == nil {

--- a/container/main.go
+++ b/container/main.go
@@ -42,11 +42,11 @@ func main() {
 	defer shutdownTracer(ctx) //nolint:errcheck
 
 	cfg := mysql.Config{
-		User:                 os.Getenv("DATABASE_USER"),
-		Passwd:               os.Getenv("DATABASE_PASSWORD"),
-		Net:                  os.Getenv("DATABASE_NET"),
-		Addr:                 os.Getenv("DATABASE_HOST"),
-		DBName:               os.Getenv("DATABASE_NAME"),
+		User:                 os.Getenv("IPAM_DATABASE_USER"),
+		Passwd:               os.Getenv("IPAM_DATABASE_PASSWORD"),
+		Net:                  os.Getenv("IPAM_DATABASE_NET"),
+		Addr:                 os.Getenv("IPAM_DATABASE_HOST"),
+		DBName:               os.Getenv("IPAM_DATABASE_NAME"),
 		MultiStatements:      true,
 		AllowNativePasswords: true,
 	}
@@ -60,8 +60,8 @@ func main() {
 	db.SetMaxIdleConns(5)
 	defer db.Close()
 
-	if os.Getenv("DISABLE_DATABASE_MIGRATION") != "TRUE" {
-		if err = server.MigrateDatabase(os.Getenv("DATABASE_NAME"), db); err != nil {
+	if os.Getenv("IPAM_DISABLE_DATABASE_MIGRATION") != "TRUE" {
+		if err = server.MigrateDatabase(os.Getenv("IPAM_DATABASE_NAME"), db); err != nil {
 			slog.Error("failed to migrate database", "error", err)
 			os.Exit(1)
 		}
@@ -70,10 +70,10 @@ func main() {
 	app := server.NewApp(db)
 
 	port := int64(8080)
-	if os.Getenv("PORT") != "" {
-		port, err = strconv.ParseInt(os.Getenv("PORT"), 10, 64)
+	if os.Getenv("IPAM_PORT") != "" {
+		port, err = strconv.ParseInt(os.Getenv("IPAM_PORT"), 10, 64)
 		if err != nil {
-			slog.Error("failed to parse PORT", "value", os.Getenv("PORT"), "error", err)
+			slog.Error("failed to parse PORT", "value", os.Getenv("IPAM_PORT"), "error", err)
 			os.Exit(1)
 		}
 	}

--- a/container/server/api.go
+++ b/container/server/api.go
@@ -48,6 +48,135 @@ type RangeRequest struct {
 	Labels     map[string]string `json:"labels"`
 }
 
+type ImportRangeItem struct {
+	Name   string            `json:"name"`
+	Cidr   string            `json:"cidr"`
+	Domain string            `json:"domain"`
+	Parent string            `json:"parent"`
+	Labels map[string]string `json:"labels"`
+}
+
+type ImportError struct {
+	Name  string `json:"name"`
+	Cidr  string `json:"cidr"`
+	Error string `json:"error"`
+}
+
+type ImportResult struct {
+	Imported int           `json:"imported"`
+	Skipped  int           `json:"skipped"`
+	Errors   []ImportError `json:"errors"`
+}
+
+func ImportRanges(c *fiber.Ctx) error {
+	ctx := context.Background()
+
+	var items []ImportRangeItem
+	if err := c.BodyParser(&items); err != nil {
+		return c.Status(400).JSON(&fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("Bad format %v", err),
+		})
+	}
+
+	result := ImportResult{Errors: []ImportError{}}
+
+	for _, item := range items {
+		if item.Name == "" {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: "name is required"})
+			continue
+		}
+		if len(item.Name) > 255 {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: "name must not exceed 255 characters"})
+			continue
+		}
+		if item.Cidr == "" {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: "cidr is required"})
+			continue
+		}
+		labelErr := false
+		for k, v := range item.Labels {
+			if k == "" || v == "" {
+				result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: "label keys and values must not be empty"})
+				labelErr = true
+				break
+			}
+			if len(k) > 63 {
+				result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("label key %q must not exceed 63 characters", k)})
+				labelErr = true
+				break
+			}
+			if len(v) > 255 {
+				result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("label value for key %q must not exceed 255 characters", k)})
+				labelErr = true
+				break
+			}
+		}
+		if labelErr {
+			continue
+		}
+
+		var routingDomain *RoutingDomain
+		var err error
+		if item.Domain == "" {
+			routingDomain, err = getDefaultRoutingDomain()
+		} else {
+			domainID, parseErr := strconv.ParseInt(item.Domain, 10, 64)
+			if parseErr != nil {
+				result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("invalid domain: %v", parseErr)})
+				continue
+			}
+			routingDomain, err = GetRoutingDomainFromDB(domainID)
+		}
+		if err != nil {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("could not resolve domain: %v", err)})
+			continue
+		}
+
+		exists, err := rangeExistsByCidrAndDomain(item.Cidr, routingDomain.Id)
+		if err != nil {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("database error: %v", err)})
+			continue
+		}
+		if exists {
+			result.Skipped++
+			continue
+		}
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("database error: %v", err)})
+			continue
+		}
+
+		parentID := int64(-1)
+		if item.Parent != "" {
+			parentID, err = strconv.ParseInt(item.Parent, 10, 64)
+			if err != nil {
+				_ = tx.Rollback()
+				result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("invalid parent: %v", err)})
+				continue
+			}
+		}
+
+		id, err := CreateRangeInDb(tx, parentID, routingDomain.Id, item.Name, item.Cidr, item.Labels)
+		if err != nil {
+			_ = tx.Rollback()
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("failed to import: %v", err)})
+			continue
+		}
+		if err = tx.Commit(); err != nil {
+			result.Errors = append(result.Errors, ImportError{Name: item.Name, Cidr: item.Cidr, Error: fmt.Sprintf("commit failed: %v", err)})
+			continue
+		}
+
+		writeAuditLog(ActionCreate, ResourceRange, int(id), item.Name, map[string]string{"cidr": item.Cidr})
+		result.Imported++
+	}
+
+	return c.Status(200).JSON(result)
+}
+
 func GetRanges(c *fiber.Ctx) error {
 	var results []*fiber.Map
 	ranges, err := GetRangesFromDB(c.Query("name"))

--- a/container/server/api.go
+++ b/container/server/api.go
@@ -452,14 +452,19 @@ func findNewLeaseAndInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDoma
 			"message": fmt.Sprintf("Unable to create new Subnet Lease  %v", err),
 		})
 	}
-	if os.Getenv("IPAM_CAI_ORG_ID") != "" && routingDomain.Vpcs != "" {
+	if orgID := os.Getenv("IPAM_CAI_ORG_ID"); orgID != "" && routingDomain.Vpcs != "" {
 		vpcs := strings.Split(routingDomain.Vpcs, ",")
-		caiRanges, err := GetCAISubnetsForNetworks(vpcs)
+		var caiRanges []Range
+		if os.Getenv("IPAM_CAI_DB_SYNC") == "TRUE" {
+			caiRanges, err = GetCAISubnetsForNetworks(vpcs)
+		} else {
+			caiRanges, err = getLiveCAISubnetsForNetworks(context.Background(), orgID, vpcs)
+		}
 		if err != nil {
 			_ = tx.Rollback()
 			return c.Status(503).JSON(&fiber.Map{
 				"success": false,
-				"message": fmt.Sprintf("CAI DB query failed: %v", err),
+				"message": fmt.Sprintf("CAI lookup failed: %v", err),
 			})
 		}
 		for _, r := range caiRanges {

--- a/container/server/api.go
+++ b/container/server/api.go
@@ -452,12 +452,12 @@ func findNewLeaseAndInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDoma
 			"message": fmt.Sprintf("Unable to create new Subnet Lease  %v", err),
 		})
 	}
-	if os.Getenv("CAI_ORG_ID") != "" {
-		log.Printf("CAI for org %s enabled", os.Getenv("CAI_ORG_ID"))
+	if os.Getenv("IPAM_CAI_ORG_ID") != "" {
+		log.Printf("CAI for org %s enabled", os.Getenv("IPAM_CAI_ORG_ID"))
 		// Integrating ranges from the VPC -- start
 		vpcs := strings.Split(routingDomain.Vpcs, ",")
 		log.Printf("Looking for subnets in vpcs %v", vpcs)
-		ranges, err := GetRangesForNetwork(fmt.Sprintf("organizations/%s", os.Getenv("CAI_ORG_ID")), vpcs)
+		ranges, err := GetRangesForNetwork(fmt.Sprintf("organizations/%s", os.Getenv("IPAM_CAI_ORG_ID")), vpcs)
 		if err != nil {
 			_ = tx.Rollback()
 			return c.Status(503).JSON(&fiber.Map{

--- a/container/server/api.go
+++ b/container/server/api.go
@@ -452,43 +452,21 @@ func findNewLeaseAndInsert(c *fiber.Ctx, tx *sql.Tx, p RangeRequest, routingDoma
 			"message": fmt.Sprintf("Unable to create new Subnet Lease  %v", err),
 		})
 	}
-	if os.Getenv("IPAM_CAI_ORG_ID") != "" {
-		log.Printf("CAI for org %s enabled", os.Getenv("IPAM_CAI_ORG_ID"))
-		// Integrating ranges from the VPC -- start
+	if os.Getenv("IPAM_CAI_ORG_ID") != "" && routingDomain.Vpcs != "" {
 		vpcs := strings.Split(routingDomain.Vpcs, ",")
-		log.Printf("Looking for subnets in vpcs %v", vpcs)
-		ranges, err := GetRangesForNetwork(fmt.Sprintf("organizations/%s", os.Getenv("IPAM_CAI_ORG_ID")), vpcs)
+		caiRanges, err := GetCAISubnetsForNetworks(vpcs)
 		if err != nil {
 			_ = tx.Rollback()
 			return c.Status(503).JSON(&fiber.Map{
 				"success": false,
-				"message": fmt.Sprintf("error %v", err),
+				"message": fmt.Sprintf("CAI DB query failed: %v", err),
 			})
 		}
-		log.Printf("Found %d subnets in vpcs %v", len(ranges), vpcs)
-
-		for j := 0; j < len(ranges); j++ {
-			vpc_range := ranges[j]
-			if !ContainsRange(subnet_ranges, vpc_range.cidr) {
-				log.Printf("Adding range %s from CAI", vpc_range.cidr)
-				subnet_ranges = append(subnet_ranges, Range{
-					Cidr: vpc_range.cidr,
-				})
-			}
-
-			for k := 0; k < len(vpc_range.secondaryRanges); k++ {
-				secondaryRange := vpc_range.secondaryRanges[k]
-				if !ContainsRange(subnet_ranges, secondaryRange.cidr) {
-					log.Printf("Adding secondary range %s from CAI", vpc_range.cidr)
-					subnet_ranges = append(subnet_ranges, Range{
-						Cidr: secondaryRange.cidr,
-					})
-				}
+		for _, r := range caiRanges {
+			if !ContainsRange(subnet_ranges, r.Cidr) {
+				subnet_ranges = append(subnet_ranges, r)
 			}
 		}
-		// Integrating ranges from the VPC -- end
-	} else {
-		log.Printf("Not checking CAI, env variable with Org ID not set")
 	}
 
 	subnet, subnetOnes, err := findNextSubnet(int(range_size), parent.Cidr, subnet_ranges)

--- a/container/server/cai.go
+++ b/container/server/cai.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	asset "cloud.google.com/go/asset/apiv1"
@@ -71,6 +72,25 @@ func fetchCAISubnets(ctx context.Context, parent string) ([]caiSubnet, error) {
 		}
 	}
 	return subnets, nil
+}
+
+// getLiveCAISubnetsForNetworks fetches subnets directly from the CAI API (no DB)
+// and filters them by the given VPC identifiers. Used when IPAM_CAI_DB_SYNC is not enabled.
+func getLiveCAISubnetsForNetworks(ctx context.Context, orgID string, networks []string) ([]Range, error) {
+	subnets, err := fetchCAISubnets(ctx, fmt.Sprintf("organizations/%s", orgID))
+	if err != nil {
+		return nil, err
+	}
+	var result []Range
+	for _, s := range subnets {
+		for _, vpc := range networks {
+			if vpcMatches(vpc, s.network) {
+				result = append(result, Range{Cidr: s.cidr})
+				break
+			}
+		}
+	}
+	return result, nil
 }
 
 // vpcMatches returns true if the storedVpc (from routing domain) matches a CAI network URL.

--- a/container/server/cai.go
+++ b/container/server/cai.go
@@ -16,34 +16,25 @@ package server
 
 import (
 	"context"
-	"fmt"
-	"log"
-	"reflect"
+	"strings"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	assetpb "cloud.google.com/go/asset/apiv1/assetpb"
 	"google.golang.org/api/iterator"
 )
 
-type CaiSecondaryRange struct {
-	name string
-	cidr string
-}
-type CaiRange struct {
-	name            string
-	id              string
-	network         string
-	cidr            string
-	secondaryRanges []CaiSecondaryRange
+type caiSubnet struct {
+	network string
+	cidr    string
 }
 
-func GetRangesForNetwork(parent string, networks []string) ([]CaiRange, error) {
-	ctx := context.Background()
+// fetchCAISubnets returns all Subnetwork assets under parent (e.g. "organizations/123").
+// It does not filter by VPC — callers use vpcMatches to filter as needed.
+func fetchCAISubnets(ctx context.Context, parent string) ([]caiSubnet, error) {
 	client, err := asset.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-
 	defer client.Close() //nolint:errcheck
 
 	itr := client.ListAssets(ctx, &assetpb.ListAssetsRequest{
@@ -52,54 +43,42 @@ func GetRangesForNetwork(parent string, networks []string) ([]CaiRange, error) {
 		ContentType: assetpb.ContentType_RESOURCE,
 	})
 
-	ranges := make([]CaiRange, 0)
-
-	for asset, err := itr.Next(); err != iterator.Done; asset, err = itr.Next() {
-		if err != nil {
-			log.Fatal(err)
+	var subnets []caiSubnet
+	for {
+		a, err := itr.Next()
+		if err == iterator.Done {
+			break
 		}
-		if containsValue(networks, asset.Resource.Data.Fields["network"].GetStringValue()) {
-			secondaryRanges := make([]CaiSecondaryRange, 0)
-			secondary := asset.Resource.Data.Fields["secondaryIpRanges"].GetListValue().AsSlice()
-			for i := 0; i < len(secondary); i++ {
-				var rangeName string
-				var ipCidrRange string
+		if err != nil {
+			return nil, err
+		}
+		network := a.Resource.Data.Fields["network"].GetStringValue()
+		cidr := a.Resource.Data.Fields["ipCidrRange"].GetStringValue()
+		if network == "" || cidr == "" {
+			continue
+		}
+		subnets = append(subnets, caiSubnet{network: network, cidr: cidr})
 
-				iter := reflect.ValueOf(secondary[i]).MapRange()
-				for iter.Next() {
-					key := iter.Key().Interface()
-					value := iter.Value().Interface()
-					if key == "ipCidrRange" {
-						ipCidrRange = fmt.Sprintf("%s", value)
-					}
-					if key == "rangeName" {
-						rangeName = fmt.Sprintf("%s", value)
-					}
-				}
-				secondaryRanges = append(secondaryRanges, CaiSecondaryRange{
-					name: rangeName,
-					cidr: ipCidrRange,
-				})
+		// Also collect secondary ranges
+		for _, raw := range a.Resource.Data.Fields["secondaryIpRanges"].GetListValue().AsSlice() {
+			m, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
 			}
-			ranges = append(ranges, CaiRange{
-				id:              asset.Resource.Data.Fields["id"].GetStringValue(),
-				name:            asset.Name,
-				network:         asset.Resource.Data.Fields["network"].GetStringValue(),
-				cidr:            asset.Resource.Data.Fields["ipCidrRange"].GetStringValue(),
-				secondaryRanges: secondaryRanges,
-			})
-		} else {
-			log.Printf("Ignoring network %s", asset.Resource.Data.Fields["network"].GetStringValue())
+			if secondaryCidr, ok := m["ipCidrRange"].(string); ok && secondaryCidr != "" {
+				subnets = append(subnets, caiSubnet{network: network, cidr: secondaryCidr})
+			}
 		}
 	}
-	return ranges, nil
+	return subnets, nil
 }
 
-func containsValue(array []string, lookup string) bool {
-	for i := 0; i < len(array); i++ {
-		if lookup == array[i] {
-			return true
-		}
-	}
-	return false
+// vpcMatches returns true if the storedVpc (from routing domain) matches a CAI network URL.
+// Accepts both full URLs and short forms:
+//
+//	"https://www.googleapis.com/compute/v1/projects/my-proj/global/networks/my-vpc"
+//	"projects/my-proj/global/networks/my-vpc"
+//	"my-vpc"
+func vpcMatches(storedVpc, caiNetworkURL string) bool {
+	return storedVpc == caiNetworkURL || strings.HasSuffix(caiNetworkURL, "/"+storedVpc)
 }

--- a/container/server/cai_sync.go
+++ b/container/server/cai_sync.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Boozt Fashion AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+const caiSyncChunkSize = 200
+
+// SyncCAISubnets fetches all Subnetwork assets from Cloud Asset Inventory for the
+// given GCP organisation and upserts them into the cai_subnets table in chunks.
+// Subnets not seen in this sync run are removed (stale cleanup).
+// The function is idempotent and safe to call concurrently — duplicate key conflicts
+// are handled via ON DUPLICATE KEY UPDATE.
+func SyncCAISubnets(ctx context.Context, orgID string) error {
+	slog.Info("CAI sync started", "org", orgID)
+	start := time.Now()
+
+	subnets, err := fetchCAISubnets(ctx, fmt.Sprintf("organizations/%s", orgID))
+	if err != nil {
+		return fmt.Errorf("CAI fetch failed: %w", err)
+	}
+	slog.Info("CAI fetch complete", "subnets", len(subnets))
+
+	// Upsert in chunks — each chunk is its own transaction so a single failure
+	// does not roll back the entire sync.
+	for i := 0; i < len(subnets); i += caiSyncChunkSize {
+		end := i + caiSyncChunkSize
+		if end > len(subnets) {
+			end = len(subnets)
+		}
+		if err := upsertCAIChunk(ctx, subnets[i:end]); err != nil {
+			return fmt.Errorf("CAI upsert chunk %d–%d failed: %w", i, end, err)
+		}
+	}
+
+	// Remove entries that were not touched in this sync run (subnet was deleted in GCP).
+	_, err = db.ExecContext(ctx,
+		"DELETE FROM cai_subnets WHERE last_synced_at < ?", start)
+	if err != nil {
+		return fmt.Errorf("CAI stale cleanup failed: %w", err)
+	}
+
+	slog.Info("CAI sync complete", "org", orgID, "subnets", len(subnets), "duration", time.Since(start))
+	return nil
+}
+
+func upsertCAIChunk(ctx context.Context, chunk []caiSubnet) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, s := range chunk {
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO cai_subnets (network, cidr, last_synced_at) VALUES (?, ?, NOW())
+			 ON DUPLICATE KEY UPDATE last_synced_at = NOW()`,
+			s.network, s.cidr)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// StartCAISyncLoop runs an initial sync immediately (blocking) then starts a
+// background goroutine that re-syncs on the given interval.
+// The goroutine stops when ctx is cancelled.
+func StartCAISyncLoop(ctx context.Context, orgID string, interval time.Duration) error {
+	if err := SyncCAISubnets(ctx, orgID); err != nil {
+		return fmt.Errorf("initial CAI sync failed: %w", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := SyncCAISubnets(ctx, orgID); err != nil {
+					slog.Error("CAI sync failed, will retry next interval", "error", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}

--- a/container/server/cai_test.go
+++ b/container/server/cai_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Boozt Fashion AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVpcMatches(t *testing.T) {
+	fullURL := "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-vpc"
+
+	tests := []struct {
+		name      string
+		storedVpc string
+		caiURL    string
+		want      bool
+	}{
+		{"full URL exact match", fullURL, fullURL, true},
+		{"short network name", "my-vpc", fullURL, true},
+		{"projects/... path", "projects/my-project/global/networks/my-vpc", fullURL, true},
+		{"wrong name", "other-vpc", fullURL, false},
+		{"partial prefix should not match", "vpc", fullURL, false},
+		{"empty stored", "", fullURL, false},
+		{"both empty", "", "", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, vpcMatches(tc.storedVpc, tc.caiURL))
+		})
+	}
+}

--- a/container/server/data_access.go
+++ b/container/server/data_access.go
@@ -259,6 +259,32 @@ func GetRangeByCidrFromDB(tx *sql.Tx, routing_domain_id int, cidr_request string
 	}, nil
 }
 
+// GetCAISubnetsForNetworks returns all CIDRs from the cai_subnets table whose network
+// matches any of the given VPC identifiers. Both full URLs and short names are supported
+// (see vpcMatches).
+func GetCAISubnetsForNetworks(networks []string) ([]Range, error) {
+	rows, err := db.Query("SELECT network, cidr FROM cai_subnets")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var result []Range
+	for rows.Next() {
+		var network, cidrVal string
+		if err := rows.Scan(&network, &cidrVal); err != nil {
+			return nil, err
+		}
+		for _, vpc := range networks {
+			if vpcMatches(vpc, network) {
+				result = append(result, Range{Cidr: cidrVal})
+				break
+			}
+		}
+	}
+	return result, rows.Err()
+}
+
 func rangeExistsByCidrAndDomain(cidrVal string, domainID int) (bool, error) {
 	var count int
 	err := db.QueryRow("SELECT COUNT(*) FROM subnets WHERE cidr = ? AND routing_domain_id = ?", cidrVal, domainID).Scan(&count)

--- a/container/server/data_access.go
+++ b/container/server/data_access.go
@@ -259,6 +259,31 @@ func GetRangeByCidrFromDB(tx *sql.Tx, routing_domain_id int, cidr_request string
 	}, nil
 }
 
+func rangeExistsByCidrAndDomain(cidrVal string, domainID int) (bool, error) {
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM subnets WHERE cidr = ? AND routing_domain_id = ?", cidrVal, domainID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func getDefaultRoutingDomain() (*RoutingDomain, error) {
+	var routing_domain_id int
+	var name string
+	var vpcs sql.NullString
+
+	err := db.QueryRow("SELECT routing_domain_id, name, vpcs FROM routing_domains LIMIT 1").Scan(&routing_domain_id, &name, &vpcs)
+	if err != nil {
+		return nil, err
+	}
+	return &RoutingDomain{
+		Id:   routing_domain_id,
+		Name: name,
+		Vpcs: vpcs.String,
+	}, nil
+}
+
 func DeleteRangeFromDb(id int64) error {
 	_, err := db.Query("DELETE FROM subnets WHERE subnet_id = ?", id)
 

--- a/container/server/logging.go
+++ b/container/server/logging.go
@@ -21,7 +21,7 @@ import (
 
 func InitLogger() *slog.Logger {
 	var handler slog.Handler
-	if os.Getenv("LOG_FORMAT") == "text" {
+	if os.Getenv("IPAM_LOG_FORMAT") == "text" {
 		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
 	} else {
 		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})

--- a/container/server/migrations/1773939600_create_cai_subnets_table.down.sql
+++ b/container/server/migrations/1773939600_create_cai_subnets_table.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2026 Boozt Fashion AB
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+DROP TABLE IF EXISTS cai_subnets;

--- a/container/server/migrations/1773939600_create_cai_subnets_table.up.sql
+++ b/container/server/migrations/1773939600_create_cai_subnets_table.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2026 Boozt Fashion AB
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE cai_subnets (
+  id INT NOT NULL AUTO_INCREMENT,
+  network VARCHAR(512) NOT NULL,
+  cidr VARCHAR(50) NOT NULL,
+  last_synced_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY (network, cidr)
+);

--- a/container/server/provider_registry.go
+++ b/container/server/provider_registry.go
@@ -98,7 +98,7 @@ func getSigningUrl(objectName string) (string, error) {
 		return "", err
 	}
 
-	s, err := storageClient.Bucket(os.Getenv("STORAGE_BUCKET")).SignedURL(objectName, &storage.SignedURLOptions{
+	s, err := storageClient.Bucket(os.Getenv("IPAM_STORAGE_BUCKET")).SignedURL(objectName, &storage.SignedURLOptions{
 		Method:  http.MethodGet,
 		Expires: expires,
 	})

--- a/container/server/server.go
+++ b/container/server/server.go
@@ -42,6 +42,7 @@ func NewApp(database *sql.DB) *fiber.App {
 
 	// API v1
 	v1 := app.Group("/api/v1")
+	v1.Post("/ranges/import", ImportRanges)
 	v1.Post("/ranges", CreateNewRange)
 	v1.Get("/ranges", GetRanges)
 	v1.Get("/ranges/:id", GetRange)

--- a/container/server/server.go
+++ b/container/server/server.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"database/sql"
+	"os"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -42,7 +43,9 @@ func NewApp(database *sql.DB) *fiber.App {
 
 	// API v1
 	v1 := app.Group("/api/v1")
-	v1.Post("/ranges/import", ImportRanges)
+	if os.Getenv("IPAM_DISABLE_BULK_IMPORT") != "TRUE" {
+		v1.Post("/ranges/import", ImportRanges)
+	}
 	v1.Post("/ranges", CreateNewRange)
 	v1.Get("/ranges", GetRanges)
 	v1.Get("/ranges/:id", GetRange)

--- a/container/tests/cai_test.go
+++ b/container/tests/cai_test.go
@@ -42,7 +42,8 @@ func seedCAISubnets(t *testing.T, db *sql.DB, network string, cidrs []string) {
 // TestCAI_AllocationAvoidsSeededSubnets verifies that auto-allocation skips CIDRs
 // already present in cai_subnets for the domain's VPC.
 func TestCAI_AllocationAvoidsSeededSubnets(t *testing.T) {
-	t.Setenv("IPAM_CAI_ORG_ID", "fake-org") // enables CAI DB path
+	t.Setenv("IPAM_CAI_ORG_ID", "fake-org")
+	t.Setenv("IPAM_CAI_DB_SYNC", "TRUE")
 
 	database, cleanup := setupTestDB(t)
 	defer cleanup()
@@ -94,6 +95,7 @@ func TestCAI_AllocationAvoidsSeededSubnets(t *testing.T) {
 // VPC name (e.g. "my-vpc") still matches full CAI network URLs.
 func TestCAI_ShortVpcNameMatches(t *testing.T) {
 	t.Setenv("IPAM_CAI_ORG_ID", "fake-org")
+	t.Setenv("IPAM_CAI_DB_SYNC", "TRUE")
 
 	database, cleanup := setupTestDB(t)
 	defer cleanup()
@@ -138,6 +140,7 @@ func TestCAI_ShortVpcNameMatches(t *testing.T) {
 // do not block allocation in an unrelated domain.
 func TestCAI_DifferentVpcNotAffected(t *testing.T) {
 	t.Setenv("IPAM_CAI_ORG_ID", "fake-org")
+	t.Setenv("IPAM_CAI_DB_SYNC", "TRUE")
 
 	database, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/container/tests/cai_test.go
+++ b/container/tests/cai_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Boozt Fashion AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package tests
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/boozt-platform/ipam-autopilot/container/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedCAISubnets inserts rows directly into cai_subnets, simulating a CAI sync.
+func seedCAISubnets(t *testing.T, db *sql.DB, network string, cidrs []string) {
+	t.Helper()
+	for _, cidr := range cidrs {
+		_, err := db.Exec(
+			`INSERT INTO cai_subnets (network, cidr, last_synced_at) VALUES (?, ?, NOW())
+			 ON DUPLICATE KEY UPDATE last_synced_at = NOW()`,
+			network, cidr)
+		require.NoError(t, err)
+	}
+}
+
+// TestCAI_AllocationAvoidsSeededSubnets verifies that auto-allocation skips CIDRs
+// already present in cai_subnets for the domain's VPC.
+func TestCAI_AllocationAvoidsSeededSubnets(t *testing.T) {
+	t.Setenv("IPAM_CAI_ORG_ID", "fake-org") // enables CAI DB path
+
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	vpcURL := "https://www.googleapis.com/compute/v1/projects/test-proj/global/networks/test-vpc"
+
+	// Create domain with VPC
+	_, domainBody := doRequest(app, "POST", "/api/v1/domains", map[string]interface{}{
+		"name": "cai-test-domain",
+		"vpcs": []string{vpcURL},
+	})
+	var domain map[string]interface{}
+	require.NoError(t, json.Unmarshal(domainBody, &domain))
+	domainID := int(domain["id"].(float64))
+
+	// Create parent range
+	_, parentBody := doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "parent",
+		"cidr":   "10.60.0.0/16",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	var parent map[string]interface{}
+	require.NoError(t, json.Unmarshal(parentBody, &parent))
+	parentID := int(parent["id"].(float64))
+
+	// Seed cai_subnets: occupy first three /24s as if they exist in GCP
+	seedCAISubnets(t, database, vpcURL, []string{
+		"10.60.0.0/24",
+		"10.60.1.0/24",
+		"10.60.2.0/24",
+	})
+
+	// Auto-allocate — must skip the seeded CIDRs and give us 10.60.3.0/24
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":       "new-subnet",
+		"range_size": 24,
+		"parent":     fmt.Sprintf("%d", parentID),
+		"domain":     fmt.Sprintf("%d", domainID),
+	})
+	assert.Equal(t, 200, status)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	assert.Equal(t, "10.60.3.0/24", resp["cidr"])
+}
+
+// TestCAI_ShortVpcNameMatches verifies that a routing domain storing only the short
+// VPC name (e.g. "my-vpc") still matches full CAI network URLs.
+func TestCAI_ShortVpcNameMatches(t *testing.T) {
+	t.Setenv("IPAM_CAI_ORG_ID", "fake-org")
+
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	// Domain stores only short VPC name
+	_, domainBody := doRequest(app, "POST", "/api/v1/domains", map[string]interface{}{
+		"name": "short-name-domain",
+		"vpcs": []string{"test-vpc"},
+	})
+	var domain map[string]interface{}
+	require.NoError(t, json.Unmarshal(domainBody, &domain))
+	domainID := int(domain["id"].(float64))
+
+	_, parentBody := doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "parent",
+		"cidr":   "10.61.0.0/16",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	var parent map[string]interface{}
+	require.NoError(t, json.Unmarshal(parentBody, &parent))
+	parentID := int(parent["id"].(float64))
+
+	// CAI stores full URL — short name in domain must still match
+	fullURL := "https://www.googleapis.com/compute/v1/projects/test-proj/global/networks/test-vpc"
+	seedCAISubnets(t, database, fullURL, []string{"10.61.0.0/24", "10.61.1.0/24"})
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":       "new-subnet",
+		"range_size": 24,
+		"parent":     fmt.Sprintf("%d", parentID),
+		"domain":     fmt.Sprintf("%d", domainID),
+	})
+	assert.Equal(t, 200, status)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	assert.Equal(t, "10.61.2.0/24", resp["cidr"])
+}
+
+// TestCAI_DifferentVpcNotAffected verifies that subnets from a different VPC
+// do not block allocation in an unrelated domain.
+func TestCAI_DifferentVpcNotAffected(t *testing.T) {
+	t.Setenv("IPAM_CAI_ORG_ID", "fake-org")
+
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	_, domainBody := doRequest(app, "POST", "/api/v1/domains", map[string]interface{}{
+		"name": "isolated-domain",
+		"vpcs": []string{"my-vpc"},
+	})
+	var domain map[string]interface{}
+	require.NoError(t, json.Unmarshal(domainBody, &domain))
+	domainID := int(domain["id"].(float64))
+
+	_, parentBody := doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "parent",
+		"cidr":   "10.62.0.0/16",
+		"domain": fmt.Sprintf("%d", domainID),
+	})
+	var parent map[string]interface{}
+	require.NoError(t, json.Unmarshal(parentBody, &parent))
+	parentID := int(parent["id"].(float64))
+
+	// Seed subnets for a completely different VPC — should not affect our domain
+	otherVPC := "https://www.googleapis.com/compute/v1/projects/other-proj/global/networks/other-vpc"
+	seedCAISubnets(t, database, otherVPC, []string{
+		"10.62.0.0/24",
+		"10.62.1.0/24",
+		"10.62.2.0/24",
+	})
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":       "new-subnet",
+		"range_size": 24,
+		"parent":     fmt.Sprintf("%d", parentID),
+		"domain":     fmt.Sprintf("%d", domainID),
+	})
+	assert.Equal(t, 200, status)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &resp))
+	// First available since other-vpc subnets are ignored
+	assert.Equal(t, "10.62.0.0/24", resp["cidr"])
+}

--- a/container/tests/ranges_test.go
+++ b/container/tests/ranges_test.go
@@ -249,3 +249,90 @@ func TestCreateRange_LabelValueTooLong(t *testing.T) {
 	})
 	assert.Equal(t, 400, status)
 }
+
+func TestImportRanges_Basic(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges/import", []map[string]interface{}{
+		{"name": "legacy-a", "cidr": "10.50.0.0/24", "domain": fmt.Sprintf("%d", domainID)},
+		{"name": "legacy-b", "cidr": "10.50.1.0/24", "domain": fmt.Sprintf("%d", domainID)},
+	})
+	assert.Equal(t, 200, status)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, float64(2), result["imported"])
+	assert.Equal(t, float64(0), result["skipped"])
+	assert.Empty(t, result["errors"])
+}
+
+func TestImportRanges_Idempotent(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	payload := []map[string]interface{}{
+		{"name": "legacy-c", "cidr": "10.51.0.0/24", "domain": fmt.Sprintf("%d", domainID)},
+	}
+
+	doRequest(app, "POST", "/api/v1/ranges/import", payload)
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges/import", payload)
+	assert.Equal(t, 200, status)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, float64(0), result["imported"])
+	assert.Equal(t, float64(1), result["skipped"])
+}
+
+func TestImportRanges_WithLabels(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, _ := doRequestWithStatus(app, "POST", "/api/v1/ranges/import", []map[string]interface{}{
+		{
+			"name":   "legacy-d",
+			"cidr":   "10.52.0.0/24",
+			"domain": fmt.Sprintf("%d", domainID),
+			"labels": map[string]string{"env": "prod"},
+		},
+	})
+	assert.Equal(t, 200, status)
+
+	_, listBody := doRequest(app, "GET", "/api/v1/ranges?name=legacy-d", nil)
+	var ranges []map[string]interface{}
+	require.NoError(t, json.Unmarshal(listBody, &ranges))
+	require.Len(t, ranges, 1)
+	labels := ranges[0]["labels"].(map[string]interface{})
+	assert.Equal(t, "prod", labels["env"])
+}
+
+func TestImportRanges_ValidationErrors(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	status, body := doRequestWithStatus(app, "POST", "/api/v1/ranges/import", []map[string]interface{}{
+		{"name": "", "cidr": "10.53.0.0/24", "domain": fmt.Sprintf("%d", domainID)},
+		{"name": "valid", "cidr": "", "domain": fmt.Sprintf("%d", domainID)},
+		{"name": "ok", "cidr": "10.53.1.0/24", "domain": fmt.Sprintf("%d", domainID)},
+	})
+	assert.Equal(t, 200, status)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, float64(1), result["imported"])
+	assert.Len(t, result["errors"].([]interface{}), 2)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,12 @@ services:
   api:
     build: .
     environment:
-      DATABASE_USER: ipam
-      DATABASE_PASSWORD: ipam
-      DATABASE_HOST: mysql:3306
-      DATABASE_NET: tcp
-      DATABASE_NAME: ipam
-      LOG_FORMAT: text
+      IPAM_DATABASE_USER: ipam
+      IPAM_DATABASE_PASSWORD: ipam
+      IPAM_DATABASE_HOST: mysql:3306
+      IPAM_DATABASE_NET: tcp
+      IPAM_DATABASE_NAME: ipam
+      IPAM_LOG_FORMAT: text
       OTEL_EXPORTER_OTLP_ENDPOINT: jaeger:4317
     ports:
       - "8080:8080"

--- a/provider/ipam/resources/resource_ip_range.go
+++ b/provider/ipam/resources/resource_ip_range.go
@@ -227,8 +227,8 @@ func resourceDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getIdentityToken() (string, error) {
-	if os.Getenv("GCP_IDENTITY_TOKEN") != "" {
-		return os.Getenv("GCP_IDENTITY_TOKEN"), nil
+	if os.Getenv("IPAM_IDENTITY_TOKEN") != "" {
+		return os.Getenv("IPAM_IDENTITY_TOKEN"), nil
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
  - Add `POST /api/v1/ranges/import` - register pre-existing CIDRs in IPAM without auto-allocation; idempotent (same CIDR in same domain = skip); returns `{ imported, skipped, errors }` summary; each import written to audit log
  - Add `IPAM_DISABLE_BULK_IMPORT=TRUE` to disable the endpoint per environment
  - Rename all env variables to `IPAM_` prefix for consistency (`DATABASE_USER` -> `IPAM_DATABASE_USER`, `CAI_ORG_ID` -> `IPAM_CAI_ORG_ID`, `GCP_IDENTITY_TOKEN` -> `IPAM_IDENTITY_TOKEN`, etc.); `OTEL_EXPORTER_OTLP_ENDPOINT` kept as-is
  - Document Cloud Asset Inventory integration - VPC scoping per routing domain, required IAM, how it prevents collision with subnets outside IPAM
  - Document bulk import workflow - step-by-step guide from listing GCP subnets to `terraform import` into Terraform state
  - Document all env variables in README
  - Replace live CAI API query (per allocation) with DB-backed cache (`cai_subnets` table); allocation now reads from DB instead of fetching 3000 subnets on every `POST /ranges`
  - Add startup CAI sync + background goroutine (re-syncs on `IPAM_CAI_SYNC_INTERVAL`, default `5m`); stale entries cleaned up automatically each sync
  - Add `IPAM_CAI_DB_SYNC=TRUE` to opt-in to DB cache mode; default keeps original live CAI query behavior
  - Fix `log.Fatal` in CAI iterator — CAI errors now return HTTP 503 instead of crashing the server
  - Fix VPC name matching — routing domains now accept short names (e.g. `my-vpc`) in addition to full resource URLs