### PR TITLE
feat: add GPG signing for OpenTofu registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - uses: go-semantic-release/action@v1
         with:
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,5 +50,16 @@ archives:
 checksum:
   name_template: "terraform-provider-ipam-autopilot_{{ .Version }}_SHA256SUMS"
 
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ Below is a Terraform example for using IPAM Autopilot
 terraform {
   required_providers {
     ipam = {
-      version = "0.1"
-      source = "<cloud run hostname>/ipam-autopilot/ipam"
+      source  = "boozt-platform/ipam-autopilot"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
  - Adds GPG import step to release workflow (`crazy-max/ghaction-import-gpg@v6`) 
  - Adds `signs` block to `.goreleaser.yaml` — signs `SHA256SUMS` checksum file with GPG 
  - Updates README provider source to `boozt-platform/ipam-autopilot`

  Required for publishing to the OpenTofu public registry (`registry.opentofu.org`), which validates GPG-signed checksums on every release.