### PR TITLE
fix: docker job condition and goreleaser v2 config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.version != ''
     permissions:
       contents: read
       packages: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 ---
+version: 2
 builds:
   - id: provider
     dir: provider
@@ -62,4 +63,4 @@ signs:
       - "${artifact}"
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"


### PR DESCRIPTION
- Fix docker job skipping: `released == 'true'` → `version != ''` (go-semantic-release/action@v1 does not output `released`)
- Add `version: 2` to `.goreleaser.yaml` (required by goreleaser v2)
- Rename `snapshot.name_template` → `version_template` (deprecation fix)