### PR TITLE
fix: correct module source paths in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Use the provided Terraform module to deploy the IPAM backend to GCP:
 
 ```hcl
 module "ipam" {
-  source  = "boozt-platform/ipam-autopilot/google"
-  version = "~> 1.7"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam?ref=v1.8.0"
 
   project_id      = "my-project"
   region          = "europe-west1"
@@ -65,7 +64,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.7"
+      version = "~> 1.8"
     }
   }
 }
@@ -75,7 +74,7 @@ provider "ipam" {
 }
 
 module "gke_nodes" {
-  source = "boozt-platform/ipam-autopilot/google//modules/ipam-client"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-client?ref=v1.8.0"
 
   name        = "prod-gke-nodes"
   range_size  = 22

--- a/provider/docs/guides/getting-started.md
+++ b/provider/docs/guides/getting-started.md
@@ -10,12 +10,11 @@ This guide walks through deploying the IPAM Autopilot backend to GCP and allocat
 
 ## 1. Deploy the backend
 
-Use the `modules/ipam` Terraform module from the [boozt-platform/ipam-autopilot](https://github.com/boozt-platform/ipam-autopilot) repository:
+Use the `modules/ipam` module from the [boozt-platform/ipam-autopilot](https://github.com/boozt-platform/ipam-autopilot) repository:
 
 ```hcl
 module "ipam" {
-  source  = "boozt-platform/ipam-autopilot/google"
-  version = "~> 1.7"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam?ref=v1.8.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -26,7 +25,7 @@ output "ipam_url" {
 }
 ```
 
-Run `tofu apply` and note the `ipam_url` output.
+Run `tofu init && tofu apply` and note the `ipam_url` output.
 
 ## 2. Configure the provider
 
@@ -35,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.7"
+      version = "~> 1.8"
     }
   }
 }

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -10,12 +10,11 @@ This guide walks through deploying the IPAM Autopilot backend to GCP and allocat
 
 ## 1. Deploy the backend
 
-Use the `modules/ipam` Terraform module from the [boozt-platform/ipam-autopilot](https://github.com/boozt-platform/ipam-autopilot) repository:
+Use the `modules/ipam` module from the [boozt-platform/ipam-autopilot](https://github.com/boozt-platform/ipam-autopilot) repository:
 
 ```hcl
 module "ipam" {
-  source  = "boozt-platform/ipam-autopilot/google"
-  version = "~> 1.7"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam?ref=v1.8.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -26,7 +25,7 @@ output "ipam_url" {
 }
 ```
 
-Run `tofu apply` and note the `ipam_url` output.
+Run `tofu init && tofu apply` and note the `ipam_url` output.
 
 ## 2. Configure the provider
 
@@ -35,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.7"
+      version = "~> 1.8"
     }
   }
 }


### PR DESCRIPTION
Replace invalid registry-style module sources with GitHub sources using ?ref= syntax. Module versioning via 'version' attribute only works for registry-published modules, not GitHub sources.

Also bump provider version constraint from ~> 1.7 to ~> 1.8.