### PR TITLE
feat: add OCI metadata labels to container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
           tags: |
             type=raw,value=${{ needs.release.outputs.version }}
             type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=IPAM Autopilot
+            org.opencontainers.image.description=Lightweight IP Address Management backend for Terraform-managed GCP infrastructure
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Boozt Fashion AB
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/boozt-platform/ipam-autopilot
+          images: |
+            ghcr.io/boozt-platform/ipam-autopilot
+            booztpl/ipam-autopilot
           tags: |
             type=raw,value=${{ needs.release.outputs.version }}
             type=raw,value=latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 
 - Added `container/Dockerfile` - self-contained build (no infrastructure/output dependency)
 - Added `.github/workflows/docker-publish.yml` - publishes multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/boozt-platform/ipam-autopilot` on each GitHub release
+- Added OCI metadata labels to container image: `title`, `description`, `licenses`, `vendor` (plus `version`, `revision`, `created`, `source` auto-set by `docker/metadata-action`)
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Added `container/Dockerfile` - self-contained build (no infrastructure/output dependency)
 - Added `.github/workflows/docker-publish.yml` - publishes multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/boozt-platform/ipam-autopilot` on each GitHub release
 - Added OCI metadata labels to container image: `title`, `description`, `licenses`, `vendor` (plus `version`, `revision`, `created`, `source` auto-set by `docker/metadata-action`)
+- Added Docker Hub publishing to `booztpl/ipam-autopilot` alongside GHCR on each release
 
 ---
 


### PR DESCRIPTION
Adds title, description, licenses, and vendor labels to the Docker image via docker/metadata-action. Version, revision, created, and source labels are automatically set by the action on each release.

Adds Docker Hub login and pushes the image to booztpl/ipam-autopilot alongside the existing GHCR publish. Both registries receive the same tags (version + latest) and OCI metadata labels.

Closes #17
Closes #20