### PR TITLE
Feat/in place label updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
         "golang.go",
         "ms-azuretools.vscode-docker",
         "HashiCorp.HCL",
-        "hashicorp.terraform"
+        "hashicorp.terraform",
+        "exiasr.hadolint"
       ],
       "settings": {
         "go.toolsManagement.checkForUpdates": "local",

--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 echo "Installing development tools..."
 
+# Detect architecture
+ARCH=$(dpkg --print-architecture)          # amd64 | arm64
+HADOLINT_ARCH="${ARCH}"
+if [ "${ARCH}" = "amd64" ]; then
+  HADOLINT_ARCH="x86_64"
+fi
+
 # golangci-lint
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
   | sh -s -- -b "$(go env GOPATH)/bin"
@@ -10,9 +17,34 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install
 # go tools
 go install golang.org/x/tools/cmd/goimports@latest
 
+# hadolint
+HADOLINT_VERSION="v2.14.0"
+curl -sSfL "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-${HADOLINT_ARCH}" \
+  -o /usr/local/bin/hadolint
+chmod +x /usr/local/bin/hadolint
+
+# opentofu
+TOFU_VERSION="1.9.1"
+curl -sSfL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" \
+  | tar -xz -C /usr/local/bin tofu
+
+# terraform-docs
+TFDOCS_VERSION="v0.20.0"
+curl -sSfL "https://github.com/terraform-docs/terraform-docs/releases/download/${TFDOCS_VERSION}/terraform-docs-${TFDOCS_VERSION}-linux-${ARCH}.tar.gz" \
+  | tar -xz -C /usr/local/bin terraform-docs
+
+# pre-commit
+apt-get update -qq
+apt-get install -y --no-install-recommends python3-pip > /dev/null 2>&1
+pip3 install --quiet --break-system-packages pre-commit
+
 echo "All tools installed."
 echo ""
 echo "Available make targets:"
-echo "  make dev-apply    — build provider + terraform apply against docker-compose"
-echo "  make dev-destroy  — terraform destroy"
-echo "  make build-provider — build provider binary"
+echo "  make lint             - golangci-lint + hadolint"
+echo "  make test             - unit tests + tofu test"
+echo "  make test-integration - integration tests (requires Docker)"
+echo "  make dev-apply        - build provider + terraform apply against docker-compose"
+echo "  make dev-destroy      - terraform destroy"
+echo ""
+echo "Run 'pre-commit install' to enable git hooks."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           version: v2.11.3
           working-directory: provider
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: container/Dockerfile
 
   unit:
     name: Unit tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint
+        args: [container/Dockerfile]
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+        name: gofmt (container)
+        args: [-l, -w]
+        files: ^container/
+      - id: go-fmt
+        name: gofmt (provider)
+        args: [-l, -w]
+        files: ^provider/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,12 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Renamed `examples/sandbox-client` to `examples/sandbox-gcp-vpc` - extended with GCP VPC and subnet creation using IPAM-allocated CIDRs
 - Removed outdated examples: `simple-example`, `vpc-example`, `example-with-multiple-ranges`
 
+## In-place label updates
+
+- Added `PUT /api/v1/ranges/:id` - updates labels on an existing range without destroying it; accepts `{ "labels": {...} }`, validates keys/values, writes an audit log entry
+- Removed `ForceNew` from `labels` in `ipam_ip_range` provider resource - label changes now trigger an in-place update instead of destroy+recreate
+- Added `resourceUpdate` to Terraform provider - calls `PUT /ranges/:id` with the new labels map
+
 ## Provider documentation
 
 - Added `provider/docs/` - OpenTofu registry-compatible documentation generated via `terraform-plugin-docs`; covers provider index, `ipam_ip_range` resource, `ipam_routing_domain` resource, `ipam_ip_range` data source, and a getting-started guide

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,8 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Switched to `gcr.io/distroless/static-debian12:nonroot` base image - runs as `nonroot` (UID 65532) by default; explicit `USER nonroot:nonroot` instruction added for clarity
 - Added `hadolint` Dockerfile linting - `make lint-docker` runs locally; `hadolint/hadolint-action@v3.1.0` added to CI lint job
 - Added `.pre-commit-config.yaml` - `hadolint` and `gofmt` run automatically on `git commit` after `pre-commit install`
+- Updated `.devcontainer/install-tools.sh` - added `hadolint`, `opentofu`, `terraform-docs`, `pre-commit`; updated help text
+- Added `exiasr.hadolint` VS Code extension to devcontainer
 
 ## In-place label updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,12 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Renamed `examples/sandbox-client` to `examples/sandbox-gcp-vpc` - extended with GCP VPC and subnet creation using IPAM-allocated CIDRs
 - Removed outdated examples: `simple-example`, `vpc-example`, `example-with-multiple-ranges`
 
+## Dockerfile hardening + lint enforcement
+
+- Switched to `gcr.io/distroless/static-debian12:nonroot` base image - runs as `nonroot` (UID 65532) by default; explicit `USER nonroot:nonroot` instruction added for clarity
+- Added `hadolint` Dockerfile linting - `make lint-docker` runs locally; `hadolint/hadolint-action@v3.1.0` added to CI lint job
+- Added `.pre-commit-config.yaml` - `hadolint` and `gofmt` run automatically on `git commit` after `pre-commit install`
+
 ## In-place label updates
 
 - Added `PUT /api/v1/ranges/:id` - updates labels on an existing range without destroying it; accepts `{ "labels": {...} }`, validates keys/values, writes an audit log entry

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ FROM golang:1.26-bookworm AS build
 WORKDIR /go/src/app
 COPY ./container /go/src/app
 
-RUN CGO_ENABLED=0 go build -o /go/bin/app .
+RUN CGO_ENABLED=0 go build -o /go/bin/ipam-autopilot .
 
-FROM gcr.io/distroless/static-debian12
-COPY ./infrastructure/output /terraform
-COPY --from=build /go/bin/app /
-CMD ["/app"]
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /go/bin/ipam-autopilot /
+USER nonroot:nonroot
+CMD ["/ipam-autopilot"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ REPO_ROOT    := $(shell pwd)
 PROVIDER_DIR := $(REPO_ROOT)/provider
 LOCAL_DEV_DIR := $(REPO_ROOT)/examples/local-dev
 
-.PHONY: help lint test test-integration build-provider dev-setup dev-plan dev-apply dev-destroy docs docs-modules update-version
+.PHONY: help lint lint-docker test test-integration build-provider dev-setup dev-plan dev-apply dev-destroy docs docs-modules update-version
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -18,9 +18,13 @@ help: ## Show available targets
 
 ## ── Code quality ────────────────────────────────────────────────────────────
 
-lint: ## Run golangci-lint on container and provider
+lint: lint-docker ## Run all linters (Go + Dockerfile)
 	cd $(REPO_ROOT)/container && golangci-lint run ./...
 	cd $(REPO_ROOT)/provider  && golangci-lint run ./...
+
+lint-docker: ## Lint Dockerfiles with hadolint
+	hadolint $(REPO_ROOT)/Dockerfile
+	hadolint $(REPO_ROOT)/container/Dockerfile
 
 fmt: ## Format all Go code
 	cd $(REPO_ROOT)/container && gofmt -w .

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "ipam" {
   region          = "europe-west1"
   organization_id = "123456789"   # optional — enables CAI integration
 
-  image = "ghcr.io/boozt-platform/ipam-autopilot:latest"
+  image = "ghcr.io/boozt-platform/ipam-autopilot:latest"  # or booztpl/ipam-autopilot:latest
 }
 
 output "ipam_url" {
@@ -181,6 +181,7 @@ All endpoints are available under `/api/v1`:
 POST   /api/v1/ranges              allocate a new IP range (auto or direct CIDR)
 GET    /api/v1/ranges              list all ranges; optional ?name= filter
 GET    /api/v1/ranges/:id          get a single range
+PUT    /api/v1/ranges/:id          update labels on an existing range (in-place)
 DELETE /api/v1/ranges/:id          release a range
 POST   /api/v1/ranges/import       bulk-import pre-existing CIDRs (idempotent)
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /go/bin/ipam-autopilot .
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /go/bin/ipam-autopilot /
+USER nonroot:nonroot
 CMD ["/ipam-autopilot"]

--- a/container/server/api.go
+++ b/container/server/api.go
@@ -48,6 +48,10 @@ type RangeRequest struct {
 	Labels     map[string]string `json:"labels"`
 }
 
+type UpdateRangeRequest struct {
+	Labels map[string]string `json:"labels"`
+}
+
 type ImportRangeItem struct {
 	Name   string            `json:"name"`
 	Cidr   string            `json:"cidr"`
@@ -221,6 +225,68 @@ func GetRange(c *fiber.Ctx) error {
 		"name":   rang.Name,
 		"cidr":   rang.Cidr,
 		"labels": rang.Labels,
+	})
+}
+
+func UpdateRange(c *fiber.Ctx) error {
+	id, err := strconv.ParseInt(c.Params("id"), 10, 64)
+	if err != nil {
+		return c.Status(400).JSON(&fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("%v", err),
+		})
+	}
+
+	p := new(UpdateRangeRequest)
+	if err := c.BodyParser(p); err != nil {
+		return c.Status(400).JSON(&fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("Bad format %v", err),
+		})
+	}
+
+	for k, v := range p.Labels {
+		if k == "" || v == "" {
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": "label keys and values must not be empty",
+			})
+		}
+		if len(k) > 63 {
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": fmt.Sprintf("label key %q must not exceed 63 characters", k),
+			})
+		}
+		if len(v) > 255 {
+			return c.Status(400).JSON(&fiber.Map{
+				"success": false,
+				"message": fmt.Sprintf("label value for key %q must not exceed 255 characters", v),
+			})
+		}
+	}
+
+	rang, err := GetRangeFromDB(id)
+	if err != nil {
+		return c.Status(404).JSON(&fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("range not found: %v", err),
+		})
+	}
+
+	if err := UpdateRangeLabelsInDb(id, p.Labels); err != nil {
+		return c.Status(503).JSON(&fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("failed updating range: %v", err),
+		})
+	}
+
+	writeAuditLog(ActionUpdate, ResourceRange, int(id), rang.Name, map[string]string{"cidr": rang.Cidr})
+	return c.Status(200).JSON(&fiber.Map{
+		"id":     id,
+		"name":   rang.Name,
+		"cidr":   rang.Cidr,
+		"labels": p.Labels,
 	})
 }
 

--- a/container/server/audit_log.go
+++ b/container/server/audit_log.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	ActionCreate = "create"
+	ActionUpdate = "update"
 	ActionDelete = "delete"
 
 	ResourceRange  = "range"

--- a/container/server/data_access.go
+++ b/container/server/data_access.go
@@ -310,6 +310,12 @@ func getDefaultRoutingDomain() (*RoutingDomain, error) {
 	}, nil
 }
 
+func UpdateRangeLabelsInDb(id int64, labels map[string]string) error {
+	labelsJSON := marshalLabels(labels)
+	_, err := db.Exec("UPDATE subnets SET labels = ? WHERE subnet_id = ?", labelsJSON, id)
+	return err
+}
+
 func DeleteRangeFromDb(id int64) error {
 	_, err := db.Query("DELETE FROM subnets WHERE subnet_id = ?", id)
 

--- a/container/server/server.go
+++ b/container/server/server.go
@@ -49,6 +49,7 @@ func NewApp(database *sql.DB) *fiber.App {
 	v1.Post("/ranges", CreateNewRange)
 	v1.Get("/ranges", GetRanges)
 	v1.Get("/ranges/:id", GetRange)
+	v1.Put("/ranges/:id", UpdateRange)
 	v1.Delete("/ranges/:id", DeleteRange)
 
 	v1.Get("/domains", GetRoutingDomains)
@@ -64,6 +65,7 @@ func NewApp(database *sql.DB) *fiber.App {
 	app.Post("/ranges", CreateNewRange)
 	app.Get("/ranges", GetRanges)
 	app.Get("/ranges/:id", GetRange)
+	app.Put("/ranges/:id", UpdateRange)
 	app.Delete("/ranges/:id", DeleteRange)
 
 	app.Get("/domains", GetRoutingDomains)

--- a/container/tests/ranges_test.go
+++ b/container/tests/ranges_test.go
@@ -250,6 +250,75 @@ func TestCreateRange_LabelValueTooLong(t *testing.T) {
 	assert.Equal(t, 400, status)
 }
 
+func TestUpdateRange_Labels(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	_, createBody := doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "update-labels-test",
+		"cidr":   "10.40.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+		"labels": map[string]string{"env": "dev"},
+	})
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(createBody, &created))
+	id := int(created["id"].(float64))
+
+	status, body := doRequestWithStatus(app, "PUT", fmt.Sprintf("/api/v1/ranges/%d", id), map[string]interface{}{
+		"labels": map[string]string{"env": "prod", "team": "platform"},
+	})
+	assert.Equal(t, 200, status)
+
+	var updated map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &updated))
+	labels := updated["labels"].(map[string]interface{})
+	assert.Equal(t, "prod", labels["env"])
+	assert.Equal(t, "platform", labels["team"])
+}
+
+func TestUpdateRange_ClearLabels(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	domainID, _ := setupDomainAndParent(t, app)
+
+	_, createBody := doRequest(app, "POST", "/api/v1/ranges", map[string]interface{}{
+		"name":   "clear-labels-test",
+		"cidr":   "10.41.0.0/24",
+		"domain": fmt.Sprintf("%d", domainID),
+		"labels": map[string]string{"env": "dev"},
+	})
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(createBody, &created))
+	id := int(created["id"].(float64))
+
+	status, _ := doRequestWithStatus(app, "PUT", fmt.Sprintf("/api/v1/ranges/%d", id), map[string]interface{}{
+		"labels": map[string]string{},
+	})
+	assert.Equal(t, 200, status)
+
+	_, getBody := doRequest(app, "GET", fmt.Sprintf("/api/v1/ranges/%d", id), nil)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(getBody, &resp))
+	labels := resp["labels"].(map[string]interface{})
+	assert.Empty(t, labels)
+}
+
+func TestUpdateRange_NotFound(t *testing.T) {
+	database, cleanup := setupTestDB(t)
+	defer cleanup()
+	app := server.NewApp(database)
+
+	status, _ := doRequestWithStatus(app, "PUT", "/api/v1/ranges/99999", map[string]interface{}{
+		"labels": map[string]string{"env": "prod"},
+	})
+	assert.Equal(t, 404, status)
+}
+
 func TestImportRanges_Basic(t *testing.T) {
 	database, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/docs/resources/ip_range.md
+++ b/docs/resources/ip_range.md
@@ -8,7 +8,7 @@ description: |-
 
 Allocates a non-overlapping CIDR block from the IPAM Autopilot backend. The range is reserved until the resource is destroyed.
 
-~> **Note** This resource does not support in-place updates. Any change to `name`, `range_size`, `parent`, `domain`, `cidr`, or `labels` forces a new allocation.
+-> **Labels** can be updated in-place. Any change to `name`, `range_size`, `parent`, `domain`, or `cidr` forces a new allocation.
 
 ## Example Usage
 

--- a/provider/ipam/resources/resource_ip_range.go
+++ b/provider/ipam/resources/resource_ip_range.go
@@ -34,7 +34,7 @@ func ResourceIpRange() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCreate,
 		Read:   resourceRead,
-		//Update: resourceUpdate,
+		Update: resourceUpdate,
 		Delete: resourceDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -72,7 +72,6 @@ func ResourceIpRange() *schema.Resource {
 			"labels": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Key/value labels to attach to the range. Keys must be ≤ 63 characters, values ≤ 255 characters.",
 			},
@@ -149,6 +148,48 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return fmt.Errorf("failed creating range status_code=%d, status=%s,body=%s", resp.StatusCode, resp.Status, string(body))
 	}
+}
+
+func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(config.Config)
+	labels := d.Get("labels").(map[string]interface{})
+	url := fmt.Sprintf("%s/ranges/%s", config.Url, d.Id())
+
+	labelStrings := make(map[string]string, len(labels))
+	for k, v := range labels {
+		labelStrings[k] = v.(string)
+	}
+	body := map[string]interface{}{
+		"labels": labelStrings,
+	}
+	postBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed marshalling json: %v", err)
+	}
+	accessToken, err := getIdentityToken(config.Url)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve access token: %v", err)
+	}
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(postBody))
+	if err != nil {
+		return fmt.Errorf("failed creating request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed updating range: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 200 {
+		return nil
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed updating range status_code=%d, status=%s", resp.StatusCode, resp.Status)
+	}
+	return fmt.Errorf("failed updating range status_code=%d, status=%s, body=%s", resp.StatusCode, resp.Status, string(respBody))
 }
 
 func resourceRead(d *schema.ResourceData, meta interface{}) error {

--- a/provider/templates/resources/ip_range.md.tmpl
+++ b/provider/templates/resources/ip_range.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 Allocates a non-overlapping CIDR block from the IPAM Autopilot backend. The range is reserved until the resource is destroyed.
 
-~> **Note** This resource does not support in-place updates. Any change to `name`, `range_size`, `parent`, `domain`, `cidr`, or `labels` forces a new allocation.
+-> **Labels** can be updated in-place. Any change to `name`, `range_size`, `parent`, `domain`, or `cidr` forces a new allocation.
 
 ## Example Usage
 


### PR DESCRIPTION
 - Add hadolint, opentofu, terraform-docs, and pre-commit to
 - install-tools.sh so the devcontainer has everything needed to run
 - make lint, make test, make docs, and git hooks out of the box.
 - Add hadolint VS Code extension.
 - Remove outdated note that labels force replace; labels now update in-place
 - Add PUT /api/v1/ranges/:id to API reference table
 - Add booztpl/ipam-autopilot as alternative image source in README
 - Adds UpdateRange handler that accepts {"labels": {...}} and updates the labels column in-place. Validates key/value length constraints and writes an audit log entry on success. Routes registered on both `/api/v1/ranges/:id` and the legacy `/ranges/:id` path.
 - Covering with tests: label replacement, clearing all labels, and 404 on unknown ID.
 - Removes ForceNew from the labels attribute and adds resourceUpdate which calls PUT /ranges/:id. Label changes no longer trigger a destroy+recreate cycle.
 - fix: pass manifest annotations for multi-arch OCI description

Closes #15