### PR TITLE
fix: derive range_size from cidr prefix when cidr is provided

### DIFF
--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -24,7 +24,7 @@ curl -sSfL "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VE
 chmod +x /usr/local/bin/hadolint
 
 # opentofu
-TOFU_VERSION="1.9.1"
+TOFU_VERSION="1.11.5"
 curl -sSfL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.tar.gz" \
   | tar -xz -C /usr/local/bin tofu
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Test provider
         run: go test ./...
         working-directory: provider
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: "1.11.5"
+      - name: Test modules
+        run: make test-modules
 
   integration:
     name: Integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ public.key
 
 # Compiled binaries
 container/container
-provider/terraform-provider-ipam-autopilot
+provider/terraform-provider-ipam-autopilot.test.tfrc

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.dll
 *.so
 *.dylib
+terraform-provider-ipam-autopilot
 
 # Test binary, built with `go test -c`
 *.test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,11 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Renamed `examples/sandbox-client` to `examples/sandbox-gcp-vpc` - extended with GCP VPC and subnet creation using IPAM-allocated CIDRs
 - Removed outdated examples: `simple-example`, `vpc-example`, `example-with-multiple-ranges`
 
+## Provider fixes (cont.)
+
+- Derived `range_size` from `cidr` prefix when `cidr` is set - `range_size` is now optional when `cidr` is provided; the prefix length is parsed automatically; `range_size` remains required for auto-allocation (when `cidr` is omitted)
+- Removed `range_size` workaround from `modules/ipam-network` - no longer needed now that the provider derives it
+
 ## Dockerfile hardening + lint enforcement
 
 - Switched to `gcr.io/distroless/static-debian12:nonroot` base image - runs as `nonroot` (UID 65532) by default; explicit `USER nonroot:nonroot` instruction added for clarity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ Write tests before committing. All three layers apply depending on what changed:
 |---|---|---|---|
 | Go unit | `container/server/*_test.go`, `provider/ipam/resources/*_test.go` | `go test ./...` | Any Go logic change |
 | Go integration | `container/tests/*_test.go` (build tag `integration`) | `make test-integration` | Any API endpoint change |
-| HCL unit | `modules/*/tests/unit_test.tftest.hcl` | `make test` | Any module change |
+| HCL unit | `modules/*/tests/unit_test.tftest.hcl` | `make test-modules` | Any module or provider schema change |
+
+`make test-modules` builds the provider locally and runs `tofu test` with a `dev_overrides` tfrc - always tests against local code, not the published registry version. Never run `tofu test` directly in a module directory without the dev override, or it will download the published provider and miss local changes.
 
 ### 3. Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# IPAM Autopilot - Agent Instructions
+
+This file is read automatically by Claude Code at the start of every session.
+
+## Repository layout
+
+| Path | What it is |
+|---|---|
+| `container/` | Go backend (Fiber API, MySQL, Cloud Asset Inventory) |
+| `provider/` | Terraform/OpenTofu provider (terraform-plugin-sdk v2) |
+| `modules/ipam-infra/` | Terraform module - deploys backend to GCP (Cloud Run + Cloud SQL) |
+| `modules/ipam-network/` | Terraform module - registers a VPC domain + network blocks |
+| `examples/` | Working usage examples |
+| `docs/` | Generated provider docs (OpenTofu registry format) |
+| `provider/templates/` | Source templates for docs (edit these, not `docs/`) |
+
+## Full checklist for every feat or fix
+
+Work through these steps in order. Do not commit until all pass.
+
+### 1. Implementation
+
+- Follow existing code patterns in the same file/package
+- Backend changes: `container/server/api.go` (handler) + `container/server/data_access.go` (DB) + `container/server/server.go` (route registration)
+- Provider changes: `provider/ipam/resources/resource_ip_range.go` or `resource_routing_domain.go`
+- Module changes: `modules/ipam-network/main.tf` or `modules/ipam-infra/main.tf`
+
+### 2. Tests
+
+Write tests before committing. All three layers apply depending on what changed:
+
+| Layer | Location | Command | When required |
+|---|---|---|---|
+| Go unit | `container/server/*_test.go`, `provider/ipam/resources/*_test.go` | `go test ./...` | Any Go logic change |
+| Go integration | `container/tests/*_test.go` (build tag `integration`) | `make test-integration` | Any API endpoint change |
+| HCL unit | `modules/*/tests/unit_test.tftest.hcl` | `make test` | Any module change |
+
+### 3. Documentation
+
+Update every location that describes the changed behaviour:
+
+- `CHANGES.md` - always, one bullet per logical change, no bold, no em dashes
+- `README.md` - if API, env vars, or module interface changed
+- `provider/templates/resources/ip_range.md.tmpl` - if provider resource schema or behaviour changed
+- `provider/templates/guides/getting-started.md.tmpl` - if usage examples are affected
+- `docs/resources/ip_range.md` and `docs/guides/getting-started.md` - mirror changes from templates (or run `make docs`)
+- `modules/*/README.md` - if module variables/outputs changed (run `make docs-modules`)
+
+### 4. Run the full gate
+
+```bash
+make check
+```
+
+This runs: `lint` (golangci-lint + hadolint) + `fmt` (gofmt) + `test` (unit + HCL) + `build-provider`.
+
+Fix every error before proceeding. Do not skip or suppress linter warnings without a documented reason.
+
+### 5. Review checklist
+
+Go:
+- No `log.Fatal` outside `main()` - return errors instead
+- Errors wrapped with context: `fmt.Errorf("doing X: %w", err)`
+- No global mutable state outside `var db *sql.DB` pattern
+- New DB queries use `?` placeholders, never string interpolation
+
+Terraform/OpenTofu:
+- Variables have `description` and `type`
+- Sensitive outputs marked `sensitive = true`
+- New resources include a `validation` block where input can be invalid
+- `ForceNew = true` only when the API truly cannot update in-place
+
+Docker:
+- Always use a pinned, non-root base image tag
+- No secrets or credentials in image layers
+
+### 6. Commit
+
+Use conventional commits - go-semantic-release derives the version from them:
+
+| Prefix | Version bump | When to use |
+|---|---|---|
+| `feat:` | minor | new capability visible to users |
+| `fix:` | patch | bug fix |
+| `docs:` | none | documentation only |
+| `test:` | none | tests only |
+| `chore:` | none | tooling, CI, dependencies |
+
+Commit related files in logical groups (not all at once). Close issues with `Closes #N` in the commit body.
+
+### 7. After merge
+
+go-semantic-release automatically tags and releases on merge to `main`. After the new tag appears:
+
+```bash
+make update-version VERSION=vX.Y.Z
+make docs
+make docs-modules
+```
+
+Commit the version bump as `chore: update version references to vX.Y.Z`.
+
+## Key design decisions
+
+- `range_size` is derived from `cidr` prefix when `cidr` is set - do not add it redundantly in examples
+- Labels on `ipam_ip_range` update in-place (no destroy+recreate) - document this in any usage example
+- `name` on `ipam_ip_range` is `ForceNew` - it is the lookup key for `data "ipam_ip_range"` and audit log
+- `modules/ipam-network` root range uses direct CIDR insert (no `parent`) - this is intentional
+- Docker images published to both `ghcr.io/boozt-platform/ipam-autopilot` and `booztpl/ipam-autopilot`

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help: ## Show available targets
 
 ## ── Pre-commit gate ─────────────────────────────────────────────────────────
 
-check: lint fmt test build-provider ## Full local gate: lint + fmt + test + build (run before every commit)
+check: lint fmt test build-provider docs docs-modules ## Full local gate: lint + fmt + test + docs + build (run before every commit)
 
 ## ── Code quality ────────────────────────────────────────────────────────────
 
@@ -105,12 +105,12 @@ update-version: ## Update all version references (usage: make update-version VER
 		\( -name "*.md" -o -name "*.md.tmpl" -o -name "*.tf" \) \
 		-not -path "*/.terraform/*" \
 		-not -path "*/.git/*" \
-		| xargs sed -i '' \
-		-e 's|?ref=v[0-9]*\.[0-9]*\.[0-9]*|?ref=$(VERSION)|g'
+		| xargs perl -pi -e \
+		's|\?ref=v[0-9]+\.[0-9]+\.[0-9]+|?ref=$(VERSION)|g'
 	@# Update provider version constraint only in files that reference boozt-platform/ipam-autopilot
 	@grep -rl 'boozt-platform/ipam-autopilot' $(REPO_ROOT) \
 		--include="*.tf" --include="*.md" --include="*.md.tmpl" \
 		--exclude-dir=".terraform" --exclude-dir=".git" \
-		| xargs sed -i '' \
-		-e 's|version = "~> [0-9]*\.[0-9]*"|version = "~> $(MINOR)"|g'
+		| xargs perl -pi -e \
+		's|version = "~> [0-9]+\.[0-9]+"|version = "~> $(MINOR)"|g'
 	@echo "Done. Run 'make docs && make docs-modules' to regenerate docs."

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,15 @@ REPO_ROOT    := $(shell pwd)
 PROVIDER_DIR := $(REPO_ROOT)/provider
 LOCAL_DEV_DIR := $(REPO_ROOT)/examples/local-dev
 
-.PHONY: help lint lint-docker test test-integration build-provider dev-setup dev-plan dev-apply dev-destroy docs docs-modules update-version
+.PHONY: help check lint lint-docker fmt test test-modules test-integration build-provider dev-setup dev-plan dev-apply dev-destroy docs docs-modules update-version
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+## ── Pre-commit gate ─────────────────────────────────────────────────────────
+
+check: lint fmt test build-provider ## Full local gate: lint + fmt + test + build (run before every commit)
 
 ## ── Code quality ────────────────────────────────────────────────────────────
 
@@ -35,10 +39,16 @@ fmt: ## Format all Go code
 test: ## Run unit tests (container + provider + modules)
 	cd $(REPO_ROOT)/container && go test ./...
 	cd $(REPO_ROOT)/provider  && go test ./...
+	$(MAKE) test-modules
+
+test-modules: build-provider ## Run HCL unit tests for all modules using locally built provider
+	@printf 'provider_installation {\n  dev_overrides { "boozt-platform/ipam-autopilot" = "%s" }\n  direct {}\n}\n' \
+		"$(PROVIDER_DIR)" > $(REPO_ROOT)/.test.tfrc
 	@for mod in $(REPO_ROOT)/modules/*/; do \
 		echo "Testing $$(basename $$mod)..."; \
-		cd $$mod && IPAM_URL=http://localhost:8080 tofu test; \
+		cd $$mod && TF_CLI_CONFIG_FILE=$(REPO_ROOT)/.test.tfrc IPAM_URL=http://localhost:8080 tofu test; \
 	done
+	@rm -f $(REPO_ROOT)/.test.tfrc
 
 test-integration: ## Run integration tests (requires Docker)
 	cd $(REPO_ROOT)/container && go test -tags=integration -timeout=10m ./tests/...

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ test-modules: build-provider ## Run HCL unit tests for all modules using locally
 		"$(PROVIDER_DIR)" > $(REPO_ROOT)/.test.tfrc
 	@for mod in $(REPO_ROOT)/modules/*/; do \
 		echo "Testing $$(basename $$mod)..."; \
-		cd $$mod && TF_CLI_CONFIG_FILE=$(REPO_ROOT)/.test.tfrc IPAM_URL=http://localhost:8080 tofu test; \
+		cd $$mod && tofu init -upgrade -input=false -no-color > /dev/null && \
+		TF_CLI_CONFIG_FILE=$(REPO_ROOT)/.test.tfrc IPAM_URL=http://localhost:8080 tofu test; \
 	done
 	@rm -f $(REPO_ROOT)/.test.tfrc
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the `modules/ipam-infra` Terraform module to deploy the IPAM backend to GCP:
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
 
   project_id      = "my-project"
   region          = "europe-west1"
@@ -64,7 +64,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.9"
+      version = "~> 1.11"
     }
   }
 }
@@ -74,7 +74,7 @@ provider "ipam" {
 }
 
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.11.0"
 
   domain = {
     name = "prod-vpc"

--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ resource "ipam_routing_domain" "prod" {
 }
 
 resource "ipam_ip_range" "root" {
-  name       = "prod-root"
-  cidr       = "10.0.0.0/8"
-  range_size = 8 # must match the prefix length of cidr
-  domain     = ipam_routing_domain.prod.id
+  name   = "prod-root"
+  cidr   = "10.0.0.0/8"
+  domain = ipam_routing_domain.prod.id
 }
 
 resource "ipam_ip_range" "gke_nodes" {

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.9"
+      version = "~> 1.11"
     }
   }
 }

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -53,10 +53,9 @@ resource "ipam_routing_domain" "prod" {
 }
 
 resource "ipam_ip_range" "root" {
-  name       = "prod-root"
-  cidr       = "10.0.0.0/8"
-  range_size = 8 # must match the prefix length of cidr
-  domain     = ipam_routing_domain.prod.id
+  name   = "prod-root"
+  cidr   = "10.0.0.0/8"
+  domain = ipam_routing_domain.prod.id
 }
 
 resource "ipam_ip_range" "gke_nodes" {

--- a/docs/resources/ip_range.md
+++ b/docs/resources/ip_range.md
@@ -57,7 +57,6 @@ resource "ipam_ip_range" "reserved" {
 ### Required
 
 - `name` (String) Unique name for the IP range.
-- `range_size` (Number) Prefix length of the subnet to allocate (e.g. `22` for a `/22`).
 
 ### Optional
 
@@ -65,6 +64,7 @@ resource "ipam_ip_range" "reserved" {
 - `domain` (String) Routing domain ID. When omitted the first routing domain is used.
 - `labels` (Map of String) Key/value labels to attach to the range. Keys must be ≤ 63 characters, values ≤ 255 characters.
 - `parent` (String) Parent CIDR block from which the range is allocated (e.g. `10.0.0.0/16`). When omitted the routing domain's root range is used.
+- `range_size` (Number) Prefix length of the subnet to allocate (e.g. `22` for a `/22`). When `cidr` is set, this is derived automatically from the prefix length and can be omitted.
 
 ### Read-Only
 

--- a/docs/resources/ip_range.md
+++ b/docs/resources/ip_range.md
@@ -45,9 +45,9 @@ output "gke_nodes_cidr" {
 
 ```hcl
 resource "ipam_ip_range" "reserved" {
-  name       = "legacy-subnet"
-  range_size = 24
-  cidr       = "10.1.5.0/24"
+  name = "legacy-subnet"
+  cidr = "10.1.5.0/24"
+  # range_size is derived automatically from the prefix length
 }
 ```
 

--- a/examples/sandbox-gcp-vpc/providers.tf
+++ b/examples/sandbox-gcp-vpc/providers.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.8"
+      version = "~> 1.11"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "~> 1.11"
     }
   }
 }

--- a/modules/ipam-infra/README.md
+++ b/modules/ipam-infra/README.md
@@ -6,7 +6,7 @@ Deploys the IPAM Autopilot backend to GCP — Cloud Run service, Cloud SQL (MySQ
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
 
   project_id = "my-project"
   region     = "europe-west1"
@@ -30,7 +30,7 @@ output "ipam_url" {
 | <a name="input_cloud_sql_private_ip"></a> [cloud\_sql\_private\_ip](#input\_cloud\_sql\_private\_ip) | Use private IP for Cloud SQL. Requires VPC peering with servicenetworking. Recommended for production. | `bool` | `true` | no |
 | <a name="input_cloud_sql_proxy_image"></a> [cloud\_sql\_proxy\_image](#input\_cloud\_sql\_proxy\_image) | Cloud SQL Auth Proxy container image. Pin to a specific version for production stability. | `string` | `"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.21.2"` | no |
 | <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Whether to create a new Cloud SQL instance. Set to false to use an existing instance via database\_instance\_connection\_name. | `bool` | `true` | no |
-| <a name="input_database_backup_configuration"></a> [database\_backup\_configuration](#input\_database\_backup\_configuration) | Cloud SQL backup configuration for the IPAM database. | <pre>object({<br/>    enabled                        = optional(bool, true)<br/>    binary_log_enabled             = optional(bool, true)<br/>    start_time                     = optional(string, "02:00")<br/>    location                       = optional(string, null)<br/>    transaction_log_retention_days = optional(string, "7")<br/>    retained_backups               = optional(number, 7)<br/>    retention_unit                 = optional(string, "COUNT")<br/>    point_in_time_recovery_enabled = optional(bool, false)<br/>  })</pre> | `{}` | no |
+| <a name="input_database_backup_configuration"></a> [database\_backup\_configuration](#input\_database\_backup\_configuration) | Cloud SQL backup configuration for the IPAM database. | <pre>object({<br/>    enabled                        = optional(bool, true)<br/>    binary_log_enabled             = optional(bool, true)<br/>    start_time                     = optional(string, "02:00")<br/>    location                       = optional(string, null)<br/>    transaction_log_retention_days = optional(string, "7")<br/>    retained_backups               = optional(number, 14)<br/>    retention_unit                 = optional(string, "COUNT")<br/>  })</pre> | `{}` | no |
 | <a name="input_database_deletion_protection"></a> [database\_deletion\_protection](#input\_database\_deletion\_protection) | Enable deletion protection on the Cloud SQL instance. | `bool` | `true` | no |
 | <a name="input_database_instance_connection_name"></a> [database\_instance\_connection\_name](#input\_database\_instance\_connection\_name) | Existing Cloud SQL instance connection name (project:region:instance). Required when create\_database = false. | `string` | `null` | no |
 | <a name="input_database_instance_name"></a> [database\_instance\_name](#input\_database\_instance\_name) | Name for the Cloud SQL instance. | `string` | `"ipam-mysql"` | no |

--- a/modules/ipam-network/README.md
+++ b/modules/ipam-network/README.md
@@ -6,7 +6,7 @@ Registers a VPC network and its top-level IP blocks in IPAM Autopilot. Creates a
 
 ```hcl
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.11.0"
 
   domain = "prod-vpc"
   labels = { env = "prod" }
@@ -37,14 +37,14 @@ resource "ipam_ip_range" "my_team" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_domain"></a> [domain](#input\_domain) | Name of the routing domain (e.g. "prod-vpc"). Represents the VPC network in IPAM. | `string` | n/a | yes |
-| <a name="input_labels"></a> [labels](#input\_labels) | Labels applied to all network blocks. Merged with per-block labels. | `map(string)` | `{}` | no |
-| <a name="input_networks"></a> [networks](#input\_networks) | Map of top-level network blocks to register. Key is the block name, value contains the prefix size and optional labels. | <pre>map(object({<br/>    size   = number<br/>    labels = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | Routing domain definition. name is the domain identifier (e.g. "prod-vpc"); cidr is the root address space allocated to it (e.g. "10.0.0.0/8"). | <pre>object({<br/>    name = string<br/>    cidr = string<br/>  })</pre> | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels applied to all resources. Per-network labels override these when set. | `map(string)` | `{}` | no |
+| <a name="input_networks"></a> [networks](#input\_networks) | Map of network blocks to carve from the domain's root CIDR. Key is the block name; size is the prefix length. labels overrides the module-level labels when set. | <pre>map(object({<br/>    size   = number<br/>    labels = optional(map(string))<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | Routing domain ID. |
+| <a name="output_domain"></a> [domain](#output\_domain) | Routing domain details. |
 | <a name="output_networks"></a> [networks](#output\_networks) | Map of registered network blocks with their allocated CIDRs. |
 <!-- END_TF_DOCS -->

--- a/modules/ipam-network/main.tf
+++ b/modules/ipam-network/main.tf
@@ -11,11 +11,10 @@ resource "ipam_routing_domain" "this" {
 }
 
 resource "ipam_ip_range" "root" {
-  name       = var.domain.name
-  cidr       = var.domain.cidr
-  range_size = tonumber(split("/", var.domain.cidr)[1])
-  domain     = ipam_routing_domain.this.id
-  labels     = var.labels
+  name   = var.domain.name
+  cidr   = var.domain.cidr
+  domain = ipam_routing_domain.this.id
+  labels = var.labels
 }
 
 resource "ipam_ip_range" "network" {

--- a/modules/ipam-network/providers.tf
+++ b/modules/ipam-network/providers.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.8"
+      version = "~> 1.11"
     }
   }
 }

--- a/modules/ipam-network/tests/unit_test.tftest.hcl
+++ b/modules/ipam-network/tests/unit_test.tftest.hcl
@@ -16,8 +16,9 @@ mock_provider "ipam" {
 
   mock_resource "ipam_ip_range" {
     defaults = {
-      id   = "1"
-      cidr = "10.0.0.0/8"
+      id         = "1"
+      cidr       = "10.0.0.0/8"
+      range_size = 8
     }
   }
 }

--- a/provider/ipam/resources/resource_ip_range.go
+++ b/provider/ipam/resources/resource_ip_range.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -46,9 +47,10 @@ func ResourceIpRange() *schema.Resource {
 			},
 			"range_size": {
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
-				Description: "Prefix length of the subnet to allocate (e.g. `22` for a `/22`).",
+				Description: "Prefix length of the subnet to allocate (e.g. `22` for a `/22`). When `cidr` is set, this is derived automatically from the prefix length and can be omitted.",
 			},
 			"parent": {
 				Type:        schema.TypeString,
@@ -78,6 +80,21 @@ func ResourceIpRange() *schema.Resource {
 		},
 	}
 }
+func resolveRangeSize(rangeSize int, cidr string) (int, error) {
+	if rangeSize == 0 && cidr == "" {
+		return 0, fmt.Errorf("at least one of range_size or cidr must be set")
+	}
+	if rangeSize == 0 && cidr != "" {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid cidr %q: %v", cidr, err)
+		}
+		ones, _ := ipNet.Mask.Size()
+		return ones, nil
+	}
+	return rangeSize, nil
+}
+
 func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(config.Config)
 	range_size := d.Get("range_size").(int)
@@ -85,10 +102,15 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	domain := d.Get("domain").(string)
 	cidr := d.Get("cidr").(string)
+
+	derived, err := resolveRangeSize(range_size, cidr)
+	if err != nil {
+		return err
+	}
+	range_size = derived
 	labels := d.Get("labels").(map[string]interface{})
 	url := fmt.Sprintf("%s/ranges", config.Url)
 	var postBody []byte
-	var err error
 	body := map[string]interface{}{
 		"range_size": range_size,
 		"name":       name,

--- a/provider/ipam/resources/resource_ip_range_test.go
+++ b/provider/ipam/resources/resource_ip_range_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Boozt Fashion AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resources
+
+import (
+	"testing"
+)
+
+func TestResolveRangeSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		rangeSize int
+		cidr      string
+		want      int
+		wantErr   bool
+	}{
+		{
+			name:      "derives from /8 cidr",
+			rangeSize: 0,
+			cidr:      "10.0.0.0/8",
+			want:      8,
+		},
+		{
+			name:      "derives from /22 cidr",
+			rangeSize: 0,
+			cidr:      "10.0.4.0/22",
+			want:      22,
+		},
+		{
+			name:      "derives from /28 cidr",
+			rangeSize: 0,
+			cidr:      "192.168.1.0/28",
+			want:      28,
+		},
+		{
+			name:      "explicit range_size used when cidr not set",
+			rangeSize: 24,
+			cidr:      "",
+			want:      24,
+		},
+		{
+			name:      "explicit range_size takes precedence when both set",
+			rangeSize: 24,
+			cidr:      "10.0.0.0/24",
+			want:      24,
+		},
+		{
+			name:    "error when both empty",
+			wantErr: true,
+		},
+		{
+			name:    "error on invalid cidr",
+			cidr:    "not-a-cidr",
+			wantErr: true,
+		},
+		{
+			name:      "plain ip without prefix - range_size provided explicitly",
+			rangeSize: 24,
+			cidr:      "10.0.0.0",
+			want:      24,
+		},
+		{
+			name:      "plain ip without prefix - no range_size - error",
+			rangeSize: 0,
+			cidr:      "10.0.0.0",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRangeSize(tt.rangeSize, tt.cidr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveRangeSize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("resolveRangeSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.9.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.9"
+      version = "~> 1.11"
     }
   }
 }

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -53,10 +53,9 @@ resource "ipam_routing_domain" "prod" {
 }
 
 resource "ipam_ip_range" "root" {
-  name       = "prod-root"
-  cidr       = "10.0.0.0/8"
-  range_size = 8 # must match the prefix length of cidr
-  domain     = ipam_routing_domain.prod.id
+  name   = "prod-root"
+  cidr   = "10.0.0.0/8"
+  domain = ipam_routing_domain.prod.id
 }
 
 resource "ipam_ip_range" "gke_nodes" {

--- a/provider/templates/resources/ip_range.md.tmpl
+++ b/provider/templates/resources/ip_range.md.tmpl
@@ -45,9 +45,9 @@ output "gke_nodes_cidr" {
 
 ```hcl
 resource "ipam_ip_range" "reserved" {
-  name       = "legacy-subnet"
-  range_size = 24
-  cidr       = "10.1.5.0/24"
+  name = "legacy-subnet"
+  cidr = "10.1.5.0/24"
+  # range_size is derived automatically from the prefix length
 }
 ```
 


### PR DESCRIPTION
Closes #19

When `cidr` is set on `ipam_ip_range`, the provider now derives `range_size` automatically from the prefix length. `range_size` remains required for auto-allocation (when `cidr` is omitted).

Changes:
- `range_size` is now optional/computed in the provider schema
- Added `resolveRangeSize` helper that parses the prefix from cidr
- Removed `range_size` workaround from `modules/ipam-network` root range
- Added unit tests for `resolveRangeSize` (9 cases)
- Added integration tests for in-place label updates (PUT /ranges/:id)
- Fixed `make update-version` for Linux (perl -pi instead of sed -i '')
- Added CLAUDE.md with full dev process checklist
- Added `make check` gate and `make test-modules` with local provider override
- Updated devcontainer with hadolint, opentofu, terraform-docs, pre-commit
- Added `.pre-commit-config.yaml`
