### PR TITLE
feat: add database_edition variable to ipam-infra module

### DIFF
--- a/modules/ipam-infra/main.tf
+++ b/modules/ipam-infra/main.tf
@@ -102,6 +102,7 @@ module "mysql" {
   region             = var.region
   zone               = var.zone
   tier               = var.database_tier
+  edition            = var.database_edition
   db_name            = var.database_name
   db_collation       = var.db_collation
   vpc_network        = data.google_compute_network.vpc.id

--- a/modules/ipam-infra/tests/unit_test.tftest.hcl
+++ b/modules/ipam-infra/tests/unit_test.tftest.hcl
@@ -160,6 +160,40 @@ run "backup_configuration_custom_values_accepted" {
   }
 }
 
+# ── Database edition ─────────────────────────────────────────────────────────
+
+run "database_edition_defaults_to_enterprise" {
+  command = plan
+
+  assert {
+    condition     = module.mysql[0].instance_name != ""
+    error_message = "MySQL instance should be planned with default ENTERPRISE edition."
+  }
+}
+
+run "database_edition_enterprise_plus_accepted" {
+  command = plan
+
+  variables {
+    database_edition = "ENTERPRISE_PLUS"
+  }
+
+  assert {
+    condition     = module.mysql[0].instance_name != ""
+    error_message = "MySQL instance should be planned with ENTERPRISE_PLUS edition."
+  }
+}
+
+run "database_edition_invalid_value_rejected" {
+  command = plan
+
+  variables {
+    database_edition = "INVALID"
+  }
+
+  expect_failures = [var.database_edition]
+}
+
 # ── Private Service Access ────────────────────────────────────────────────────
 
 run "private_service_access_created_with_private_ip" {

--- a/modules/ipam-infra/variables.tf
+++ b/modules/ipam-infra/variables.tf
@@ -87,9 +87,19 @@ variable "database_instance_name" {
 }
 
 variable "database_tier" {
-  description = "Cloud SQL machine tier (e.g. db-f1-micro, db-n1-standard-1)."
+  description = "Cloud SQL machine tier (e.g. db-f1-micro, db-custom-2-3840, db-perf-optimized-N-2)."
   type        = string
   default     = "db-f1-micro"
+}
+
+variable "database_edition" {
+  description = "Cloud SQL edition: ENTERPRISE or ENTERPRISE_PLUS. ENTERPRISE supports db-custom-* tiers; ENTERPRISE_PLUS requires db-perf-optimized-N-* tiers."
+  type        = string
+  default     = "ENTERPRISE"
+  validation {
+    condition     = contains(["ENTERPRISE", "ENTERPRISE_PLUS"], var.database_edition)
+    error_message = "database_edition must be ENTERPRISE or ENTERPRISE_PLUS."
+  }
 }
 
 variable "database_name" {


### PR DESCRIPTION
Expose Cloud SQL edition (ENTERPRISE or ENTERPRISE_PLUS) as a configurable variable, defaulting to ENTERPRISE. This allows using db-custom-* tiers which are not supported by ENTERPRISE_PLUS (which requires db-perf-optimized-N-*).