### PR TITLE
feat: ipam-infra module improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,10 @@
     }
   },
 
+  "mounts": [
+    "source=${localEnv:HOME}/.config/gcloud,target=/root/.config/gcloud,type=bind,consistency=cached"
+  ],
+
   "remoteUser": "root",
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,20 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 
 ---
 
+## ipam-infra module improvements
+
+- Added `subnetwork` variable to `modules/ipam-infra` - allows specifying a subnetwork for Cloud Run VPC access independently of the network name; defaults to the network name when not set to preserve backwards compatibility
+- Added `module_depends_on` and `module_enabled` variables to both `modules/ipam-infra` and `modules/ipam-network` - allows passing explicit external dependencies into the module and conditionally disabling resource creation
+- Added `module_id` composite output to `modules/ipam-infra` - references all key resources so callers can depend on the full module completing
+- Renamed `cloud_run_url` output to `service_url` in `modules/ipam-infra`
+- Rewrote `examples/sandbox-gcp-vpc` to create a full GCP project from scratch using `google_project` and `random_id`; covers project creation, VPC, and IPAM backend deployment
+- Added `examples/sandbox-network` - separate example that registers a VPC domain and network blocks in IPAM and creates matching GCP subnets; runs after `sandbox-gcp-vpc` using its outputs as inputs
+- Fixed plan-time `for_each` error in `modules/ipam-infra`: computed `sa_email` local statically as `"ipam-autopilot@${var.project_id}.iam.gserviceaccount.com"` instead of reading from `google_service_account.ipam.email`; moved IAM SQL user creation out of `safer_mysql` into a standalone `google_sql_user` resource so the key is not in a `for_each`
+- Added `database_edition` variable to `modules/ipam-infra` - exposes Cloud SQL edition (ENTERPRISE or ENTERPRISE_PLUS) with validation; defaults to ENTERPRISE
+- Documented post-deploy database setup requirement in `modules/ipam-infra/README.md`: `safer_mysql` creates the IAM user but does not grant database privileges; deploy order and Cloud SQL Studio GRANT steps are documented
+
+---
+
 ## Security hardening
 
 - Added input validation for all API inputs: name (max 255 chars, no empty), CIDR (host bits check, IPv4-only), range_size (1-32), labels (control characters rejected); fixed range_size=0 bypassing validation when cidr was omitted

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Fixed plan-time `for_each` error in `modules/ipam-infra`: computed `sa_email` local statically as `"ipam-autopilot@${var.project_id}.iam.gserviceaccount.com"` instead of reading from `google_service_account.ipam.email`; moved IAM SQL user creation out of `safer_mysql` into a standalone `google_sql_user` resource so the key is not in a `for_each`
 - Added `database_edition` variable to `modules/ipam-infra` - exposes Cloud SQL edition (ENTERPRISE or ENTERPRISE_PLUS) with validation; defaults to ENTERPRISE
 - Documented post-deploy database setup requirement in `modules/ipam-infra/README.md`: `safer_mysql` creates the IAM user but does not grant database privileges; deploy order and Cloud SQL Studio GRANT steps are documented
+- Replaced private_service_access submodule with inline google_compute_global_address and google_service_networking_connection resources to avoid plan-time data source failure in fresh GCP projects where the VPC does not yet exist
+- Replaced cloud_sql_private_ip variable with cloud_run_direct_vpc: Cloud SQL is always private when create_database = true (enforced by safer_mysql); the new variable only applies when create_database = false and controls whether Cloud Run uses Direct VPC egress to reach an existing private database instance
+- PSA and Cloud SQL Auth Proxy --private-ip are now unconditional when create_database = true; Cloud Run Direct VPC and --private-ip are conditional on cloud_run_direct_vpc when create_database = false
+- Added sandbox-gcp-vpc folder_id variable and fixed google_project to accept either org_id or folder_id (GCP rejects both simultaneously)
+- Documented GCP 1-2 hour serverless-ipv4-* address release delay in modules/ipam-infra/README.md with recommended teardown procedure for sandbox setups
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ docs: build-provider ## Regenerate provider docs (run from repo root)
 	  echo 'provider "ipam" { url = "http://localhost" }'; \
 	} > $$SCHEMA_DIR/main.tf; \
 	TF_CLI_CONFIG_FILE=$$SCHEMA_DIR/override.tfrc $(shell which tofu 2>/dev/null || which terraform 2>/dev/null) -chdir=$$SCHEMA_DIR providers schema -json > $$SCHEMA; \
-	sed -i 's|registry.opentofu.org/boozt-platform/ipam-autopilot|registry.terraform.io/hashicorp/ipam|g' $$SCHEMA; \
+	perl -pi -e 's|registry.opentofu.org/boozt-platform/ipam-autopilot|registry.terraform.io/hashicorp/ipam|g' $$SCHEMA; \
 	cd $(PROVIDER_DIR) && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate \
 		--provider-name ipam \
 		--website-source-dir templates \

--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,30 @@ dev-destroy: dev-setup ## terraform destroy local dev resources
 
 ## ── Documentation ───────────────────────────────────────────────────────────
 
-docs: ## Regenerate provider docs (run from repo root)
+docs: build-provider ## Regenerate provider docs (run from repo root)
+	@SCHEMA_DIR=$$(mktemp -d) && SCHEMA=$$SCHEMA_DIR/schema.json; \
+	{ \
+	  echo 'provider_installation {'; \
+	  echo '  dev_overrides { "boozt-platform/ipam-autopilot" = "$(PROVIDER_DIR)" }'; \
+	  echo '  direct {}'; \
+	  echo '}'; \
+	} > $$SCHEMA_DIR/override.tfrc; \
+	{ \
+	  echo 'terraform {'; \
+	  echo '  required_providers {'; \
+	  echo '    ipam = { source = "boozt-platform/ipam-autopilot" }'; \
+	  echo '  }'; \
+	  echo '}'; \
+	  echo 'provider "ipam" { url = "http://localhost" }'; \
+	} > $$SCHEMA_DIR/main.tf; \
+	TF_CLI_CONFIG_FILE=$$SCHEMA_DIR/override.tfrc $(shell which tofu 2>/dev/null || which terraform 2>/dev/null) -chdir=$$SCHEMA_DIR providers schema -json > $$SCHEMA; \
+	sed -i 's|registry.opentofu.org/boozt-platform/ipam-autopilot|registry.terraform.io/hashicorp/ipam|g' $$SCHEMA; \
 	cd $(PROVIDER_DIR) && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate \
 		--provider-name ipam \
 		--website-source-dir templates \
-		--rendered-website-dir ../docs
+		--rendered-website-dir ../docs \
+		-providers-schema $$SCHEMA; \
+	rm -rf $$SCHEMA_DIR
 
 docs-modules: ## Regenerate README.md for all Terraform modules using terraform-docs
 	@for mod in $(REPO_ROOT)/modules/*/; do \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the `modules/ipam-infra` Terraform module to deploy the IPAM backend to GCP:
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
 
   project_id      = "my-project"
   region          = "europe-west1"
@@ -64,7 +64,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.11"
+      version = "~> 1.13"
     }
   }
 }
@@ -74,7 +74,7 @@ provider "ipam" {
 }
 
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.13.1"
 
   domain = {
     name = "prod-vpc"

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.11"
+      version = "~> 1.13"
     }
   }
 }

--- a/examples/sandbox-gcp-vpc/main.tf
+++ b/examples/sandbox-gcp-vpc/main.tf
@@ -6,57 +6,72 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-# Example: reserve IP ranges in IPAM then create matching GCP VPC subnets.
+# Sandbox example: creates a new GCP project and deploys the IPAM backend.
+# After applying, use examples/sandbox-network to register address space.
 #
-# Deploy the IPAM service first:
-#   cd ../infra && tofu apply
-#
-# Then apply this example:
 #   tofu init
 #   tofu apply \
-#     -var="ipam_url=$(cd ../infra && tofu output -raw ipam_url)" \
-#     -var="project_id=<your-project>"
+#     -var="billing_account=<BILLING_ACCOUNT_ID>" \
+#     -var="org_id=<ORG_ID>"
 
-# ── IPAM: reserve address space ───────────────────────────────────────────────
+# ── Project ───────────────────────────────────────────────────────────────────
 
-module "sandbox_network" {
-  source = "../../modules/ipam-network"
+resource "random_id" "project_suffix" {
+  byte_length = 4
+}
 
-  domain = {
-    name = "sandbox-vpc"
-    cidr = "10.0.0.0/8"
-  }
+resource "google_project" "sandbox" {
+  name              = "ipam-sandbox"
+  project_id        = "ipam-sandbox-${random_id.project_suffix.hex}"
+  org_id            = var.org_id
+  billing_account   = var.billing_account
+  deletion_policy   = "DELETE"
+}
+
+# ── IPAM backend ──────────────────────────────────────────────────────────────
+
+module "ipam" {
+  source = "../../modules/ipam-infra"
+
+  project_id = google_project.sandbox.project_id
+  region     = var.region
+  zone       = var.zone
+  network    = google_compute_network.sandbox.name
+  subnetwork = google_compute_subnetwork.ipam.name
+
+  image                           = "docker.io/booztpl/ipam-autopilot:latest"
+  cloud_run_allow_unauthenticated = true
+  cloud_run_ingress               = "INGRESS_TRAFFIC_ALL"
+  database_deletion_protection    = false
+  database_tier                   = "db-g1-small"
+
   labels = { env = "sandbox" }
 
-  networks = {
-    "tenant"       = { size = 16 }
-    "tenant-b"     = { size = 24 }
-    "gke-nodes"    = { size = 16, labels = { team = "sre", env = "dev" } }
-    "gke-pods"     = { size = 16 }
-    "gke-services" = { size = 16 }
-    "mgmt"         = { size = 26 }
-    "vpn-gw"       = { size = 27 }
-    "proxy"        = { size = 28 }
-    "nat"          = { size = 28 }
-  }
+  module_depends_on = [google_project.sandbox.project_id]
 }
 
-# ── GCP: VPC ──────────────────────────────────────────────────────────────────
+# ── APIs (needed before VPC creation) ────────────────────────────────────────
+
+resource "google_project_service" "compute" {
+  project            = google_project.sandbox.project_id
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+# ── VPC ───────────────────────────────────────────────────────────────────────
 
 resource "google_compute_network" "sandbox" {
-  project                 = var.project_id
+  project                 = google_project.sandbox.project_id
   name                    = "sandbox-vpc"
   auto_create_subnetworks = false
+
+  depends_on = [google_project_service.compute]
 }
 
-# ── GCP: subnets — CIDRs come from IPAM ──────────────────────────────────────
-
-resource "google_compute_subnetwork" "networks" {
-  for_each = module.sandbox_network.networks
-
-  project       = var.project_id
+resource "google_compute_subnetwork" "ipam" {
+  project       = google_project.sandbox.project_id
   region        = var.region
   network       = google_compute_network.sandbox.id
-  name          = each.value.name
-  ip_cidr_range = each.value.cidr
+  name          = "ipam"
+  ip_cidr_range = "10.255.0.0/24"
 }

--- a/examples/sandbox-gcp-vpc/main.tf
+++ b/examples/sandbox-gcp-vpc/main.tf
@@ -21,11 +21,12 @@ resource "random_id" "project_suffix" {
 }
 
 resource "google_project" "sandbox" {
-  name              = "ipam-sandbox"
-  project_id        = "ipam-sandbox-${random_id.project_suffix.hex}"
-  org_id            = var.org_id
-  billing_account   = var.billing_account
-  deletion_policy   = "DELETE"
+  name            = "ipam-sandbox"
+  project_id      = "ipam-sandbox-${random_id.project_suffix.hex}"
+  org_id          = var.folder_id == null ? var.org_id : null
+  folder_id       = var.folder_id
+  billing_account = var.billing_account
+  deletion_policy = "DELETE"
 }
 
 # ── IPAM backend ──────────────────────────────────────────────────────────────

--- a/examples/sandbox-gcp-vpc/outputs.tf
+++ b/examples/sandbox-gcp-vpc/outputs.tf
@@ -6,24 +6,13 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-output "domain" {
-  description = "IPAM routing domain details."
-  value       = module.sandbox_network.domain
+output "project_id" {
+  description = "Created GCP project ID."
+  value       = google_project.sandbox.project_id
 }
 
-output "networks" {
-  description = "IPAM-allocated network blocks with their CIDRs."
-  value       = module.sandbox_network.networks
+output "ipam_url" {
+  description = "IPAM Autopilot Cloud Run service URL."
+  value       = module.ipam.service_url
 }
 
-output "subnets" {
-  description = "Created GCP subnets keyed by network name."
-  value = {
-    for k, s in google_compute_subnetwork.networks : k => {
-      name      = s.name
-      cidr      = s.ip_cidr_range
-      region    = s.region
-      self_link = s.self_link
-    }
-  }
-}

--- a/examples/sandbox-gcp-vpc/variables.tf
+++ b/examples/sandbox-gcp-vpc/variables.tf
@@ -6,18 +6,24 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-variable "ipam_url" {
-  description = "URL of the deployed IPAM Autopilot Cloud Run service (from examples/infra output)."
+variable "billing_account" {
+  description = "GCP billing account ID to associate with the new project (e.g. 012345-ABCDEF-012345)."
   type        = string
 }
 
-variable "project_id" {
-  description = "GCP project ID to create the VPC and subnets in."
+variable "org_id" {
+  description = "GCP organization ID under which the sandbox project will be created."
   type        = string
 }
 
 variable "region" {
-  description = "GCP region for the subnets."
+  description = "GCP region for all resources."
   type        = string
   default     = "europe-west1"
+}
+
+variable "zone" {
+  description = "GCP zone for the Cloud SQL instance."
+  type        = string
+  default     = "europe-west1-b"
 }

--- a/examples/sandbox-gcp-vpc/variables.tf
+++ b/examples/sandbox-gcp-vpc/variables.tf
@@ -14,6 +14,7 @@ variable "billing_account" {
 variable "org_id" {
   description = "GCP organization ID under which the sandbox project will be created."
   type        = string
+  default     = null
 }
 
 variable "region" {
@@ -27,3 +28,10 @@ variable "zone" {
   type        = string
   default     = "europe-west1-b"
 }
+
+variable "folder_id" {
+  description = "GCP folder ID under which the sandbox project will be created (optional)."
+  type        = string
+  default     = null
+}
+

--- a/examples/sandbox-network/main.tf
+++ b/examples/sandbox-network/main.tf
@@ -1,0 +1,59 @@
+# Copyright 2026 Boozt Fashion AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Registers a VPC domain and network blocks in IPAM, then creates matching
+# GCP subnets. Run after examples/sandbox-gcp-vpc:
+#
+#   PROJECT_ID=$(tofu -chdir=../sandbox-gcp-vpc output -raw project_id)
+#   IPAM_URL=$(tofu -chdir=../sandbox-gcp-vpc output -raw ipam_url)
+#
+#   tofu init
+#   tofu apply \
+#     -var="project_id=$PROJECT_ID" \
+#     -var="ipam_url=$IPAM_URL"
+
+# ── IPAM: register address space ──────────────────────────────────────────────
+
+module "network" {
+  source = "../../modules/ipam-network"
+
+  domain = {
+    name = var.network
+    cidr = "10.0.0.0/8"
+  }
+  labels = { env = "sandbox" }
+
+  networks = {
+    "tenant"       = { size = 16 }
+    "tenant-b"     = { size = 24 }
+    "gke-nodes"    = { size = 16, labels = { team = "sre", env = "dev" } }
+    "gke-pods"     = { size = 16 }
+    "gke-services" = { size = 16 }
+    "mgmt"         = { size = 26 }
+    "vpn-gw"       = { size = 27 }
+    "proxy"        = { size = 28 }
+    "nat"          = { size = 28 }
+  }
+}
+
+# ── GCP: subnets — CIDRs come from IPAM ──────────────────────────────────────
+
+data "google_compute_network" "vpc" {
+  name    = var.network
+  project = var.project_id
+}
+
+resource "google_compute_subnetwork" "networks" {
+  for_each = module.network.networks
+
+  project       = var.project_id
+  region        = var.region
+  network       = data.google_compute_network.vpc.id
+  name          = each.value.name
+  ip_cidr_range = each.value.cidr
+}

--- a/examples/sandbox-network/outputs.tf
+++ b/examples/sandbox-network/outputs.tf
@@ -1,0 +1,29 @@
+# Copyright 2026 Boozt Fashion AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+output "domain" {
+  description = "IPAM routing domain details."
+  value       = module.network.domain
+}
+
+output "networks" {
+  description = "IPAM-allocated network blocks with their CIDRs."
+  value       = module.network.networks
+}
+
+output "subnets" {
+  description = "Created GCP subnets keyed by network name."
+  value = {
+    for k, s in google_compute_subnetwork.networks : k => {
+      name      = s.name
+      cidr      = s.ip_cidr_range
+      region    = s.region
+      self_link = s.self_link
+    }
+  }
+}

--- a/examples/sandbox-network/providers.tf
+++ b/examples/sandbox-network/providers.tf
@@ -7,8 +7,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 
 # Prerequisites:
+#   - IPAM backend deployed (see examples/sandbox-gcp-vpc)
 #   - gcloud auth application-default login
-#   - Billing account and organization ID
 
 terraform {
   required_version = ">= 1.7"
@@ -17,17 +17,18 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.26"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.8"
+    ipam = {
+      source  = "boozt-platform/ipam-autopilot"
+      version = "~> 1.13"
     }
   }
 }
 
 provider "google" {
-  region = var.region
+  project = var.project_id
+  region  = var.region
 }
 
-provider "google-beta" {
-  region = var.region
+provider "ipam" {
+  url = var.ipam_url
 }

--- a/examples/sandbox-network/variables.tf
+++ b/examples/sandbox-network/variables.tf
@@ -1,0 +1,29 @@
+# Copyright 2026 Boozt Fashion AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+variable "ipam_url" {
+  description = "IPAM Autopilot service URL (from examples/sandbox-gcp-vpc output ipam_url)."
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID where subnets will be created (from examples/sandbox-gcp-vpc output project_id)."
+  type        = string
+}
+
+variable "network" {
+  description = "VPC network name to create subnets in."
+  type        = string
+  default     = "sandbox-vpc"
+}
+
+variable "region" {
+  description = "GCP region for subnets."
+  type        = string
+  default     = "europe-west1"
+}

--- a/modules/ipam-infra/README.md
+++ b/modules/ipam-infra/README.md
@@ -19,29 +19,46 @@ output "ipam_url" {
 
 ## Post-deploy database setup
 
-After the first `tofu apply` on a fresh Cloud SQL instance, the IPAM service account must be granted database-level privileges. The module creates the IAM user but does not run any SQL — this is intentional (see [issue](https://github.com/boozt-platform/terraform-provider-ipam-autopilot/issues/31)).
+The module automatically grants the minimum required MySQL privileges to the IPAM service account via a one-off Cloud Run Job (`<cloud_run_name>-db-grant`). This job runs during `tofu apply` via a `local-exec` provisioner after the Cloud SQL instance and the IAM user are created.
 
-**Recommended deploy order:**
+The GRANT job uses a dedicated `ipam-db-setup` service account that reads the `default` MySQL superuser password from Secret Manager. The IPAM application service account never has superuser credentials.
 
-```
-1. tofu apply -target=module.ipam.module.mysql
-2. Grant database privileges (see below)
-3. tofu apply
-```
-
-**Grant privileges using Cloud SQL Studio** (GCP Console → Cloud SQL → your instance → Studio):
-
-Connect as a built-in user with admin rights, then run:
+The job applies the following minimum privileges required for schema migrations and runtime:
 
 ```sql
-GRANT ALL ON `ipam`.* TO 'ipam-autopilot'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, INDEX, LOCK TABLES, REFERENCES ON ipam.* TO 'ipam-autopilot'@'%';
 ```
 
-Replace `ipam` with your `database_name` value if changed from the default, and `ipam-autopilot` with the service account prefix if your project ID differs.
+### Requirements for the Terraform executor
 
-The `default` user created by the module has hostname `cloudsqlproxy~%` and cannot be used in Cloud SQL Studio. Create a temporary built-in admin user via Cloud SQL Console → Users → Add user account, use it to run the GRANT, then delete it.
+The machine (or CI/CD runner) running `tofu apply` must have:
 
-After granting, restart or redeploy the Cloud Run service so database migrations run on the next startup.
+- `gcloud` CLI installed and authenticated as a principal with `roles/run.developer` (or `run.jobs.run`) on the project
+- Network access to the Cloud Run Jobs API (`run.googleapis.com`)
+
+### Re-running the GRANT
+
+The job re-runs automatically when the privilege set changes — the GRANT SQL is hashed into `triggers_replace` on a `terraform_data` resource. Updating to a new module version that adds privileges triggers a re-run on the next `tofu apply`.
+
+To force a re-run manually without changing the GRANT:
+
+```bash
+tofu apply -replace='module.ipam.terraform_data.run_db_grant[0]'
+```
+
+## Destroying infrastructure with cloud_sql_private_ip = true
+
+When `cloud_sql_private_ip = true`, Cloud Run uses Direct VPC egress, which causes GCP to create a `serverless-ipv4-*` internal address reservation in the subnetwork. GCP releases this reservation asynchronously — per GCP documentation this can take up to 1-2 hours after the Cloud Run service is deleted. If you attempt to delete the subnetwork within that window, Terraform will fail with `resourceInUseByAnotherResource`.
+
+This only affects configurations where the subnetwork is in the same Terraform state as the module. The recommended pattern for production is to manage networking (VPC, subnets) in a separate state from the IPAM module — in that case, `tofu destroy` on the module does not touch the subnet and the issue does not arise.
+
+For sandbox or single-state setups, the safest teardown is to delete the entire project:
+
+```bash
+gcloud projects delete <project-id>
+```
+
+Project deletion bypasses all resource-level reservation checks and completes immediately.
 
 <!-- BEGIN_TF_DOCS -->
 ## Inputs
@@ -50,10 +67,10 @@ After granting, restart or redeploy the Cloud Run service so database migrations
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloud_run_allow_unauthenticated"></a> [cloud\_run\_allow\_unauthenticated](#input\_cloud\_run\_allow\_unauthenticated) | Allow unauthenticated (public) access to the Cloud Run service. Enable only for testing/sandbox; production should use IAM-authenticated callers. | `bool` | `false` | no |
 | <a name="input_cloud_run_deletion_protection"></a> [cloud\_run\_deletion\_protection](#input\_cloud\_run\_deletion\_protection) | Enable deletion protection on the Cloud Run service. | `bool` | `false` | no |
+| <a name="input_cloud_run_direct_vpc"></a> [cloud\_run\_direct\_vpc](#input\_cloud\_run\_direct\_vpc) | Connect Cloud Run to the VPC using Direct VPC egress. Required when the Cloud SQL instance is on a private IP. Only relevant when create\_database = false; when create\_database = true the database is always private and Direct VPC is always enabled. | `bool` | `true` | no |
 | <a name="input_cloud_run_ingress"></a> [cloud\_run\_ingress](#input\_cloud\_run\_ingress) | Cloud Run ingress setting. One of: INGRESS\_TRAFFIC\_ALL, INGRESS\_TRAFFIC\_INTERNAL\_ONLY, INGRESS\_TRAFFIC\_INTERNAL\_LOAD\_BALANCER. | `string` | `"INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"` | no |
 | <a name="input_cloud_run_max_instances"></a> [cloud\_run\_max\_instances](#input\_cloud\_run\_max\_instances) | Maximum number of Cloud Run instances. | `number` | `10` | no |
 | <a name="input_cloud_run_name"></a> [cloud\_run\_name](#input\_cloud\_run\_name) | Name for the Cloud Run service. | `string` | `"ipam"` | no |
-| <a name="input_cloud_sql_private_ip"></a> [cloud\_sql\_private\_ip](#input\_cloud\_sql\_private\_ip) | Use private IP for Cloud SQL. Requires VPC peering with servicenetworking. Recommended for production. | `bool` | `true` | no |
 | <a name="input_cloud_sql_proxy_image"></a> [cloud\_sql\_proxy\_image](#input\_cloud\_sql\_proxy\_image) | Cloud SQL Auth Proxy container image. Pin to a specific version for production stability. | `string` | `"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.21.2"` | no |
 | <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Whether to create a new Cloud SQL instance. Set to false to use an existing instance via database\_instance\_connection\_name. | `bool` | `true` | no |
 | <a name="input_database_backup_configuration"></a> [database\_backup\_configuration](#input\_database\_backup\_configuration) | Cloud SQL backup configuration for the IPAM database. | <pre>object({<br/>    enabled                        = optional(bool, true)<br/>    binary_log_enabled             = optional(bool, true)<br/>    start_time                     = optional(string, "02:00")<br/>    location                       = optional(string, null)<br/>    transaction_log_retention_days = optional(string, "7")<br/>    retained_backups               = optional(number, 14)<br/>    retention_unit                 = optional(string, "COUNT")<br/>  })</pre> | `{}` | no |

--- a/modules/ipam-infra/README.md
+++ b/modules/ipam-infra/README.md
@@ -6,7 +6,7 @@ Deploys the IPAM Autopilot backend to GCP — Cloud Run service, Cloud SQL (MySQ
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
 
   project_id = "my-project"
   region     = "europe-west1"
@@ -16,6 +16,32 @@ output "ipam_url" {
   value = module.ipam.cloud_run_url
 }
 ```
+
+## Post-deploy database setup
+
+After the first `tofu apply` on a fresh Cloud SQL instance, the IPAM service account must be granted database-level privileges. The module creates the IAM user but does not run any SQL — this is intentional (see [issue](https://github.com/boozt-platform/terraform-provider-ipam-autopilot/issues/31)).
+
+**Recommended deploy order:**
+
+```
+1. tofu apply -target=module.ipam.module.mysql
+2. Grant database privileges (see below)
+3. tofu apply
+```
+
+**Grant privileges using Cloud SQL Studio** (GCP Console → Cloud SQL → your instance → Studio):
+
+Connect as a built-in user with admin rights, then run:
+
+```sql
+GRANT ALL ON `ipam`.* TO 'ipam-autopilot'@'%';
+```
+
+Replace `ipam` with your `database_name` value if changed from the default, and `ipam-autopilot` with the service account prefix if your project ID differs.
+
+The `default` user created by the module has hostname `cloudsqlproxy~%` and cannot be used in Cloud SQL Studio. Create a temporary built-in admin user via Cloud SQL Console → Users → Add user account, use it to run the GRANT, then delete it.
+
+After granting, restart or redeploy the Cloud Run service so database migrations run on the next startup.
 
 <!-- BEGIN_TF_DOCS -->
 ## Inputs
@@ -32,26 +58,31 @@ output "ipam_url" {
 | <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Whether to create a new Cloud SQL instance. Set to false to use an existing instance via database\_instance\_connection\_name. | `bool` | `true` | no |
 | <a name="input_database_backup_configuration"></a> [database\_backup\_configuration](#input\_database\_backup\_configuration) | Cloud SQL backup configuration for the IPAM database. | <pre>object({<br/>    enabled                        = optional(bool, true)<br/>    binary_log_enabled             = optional(bool, true)<br/>    start_time                     = optional(string, "02:00")<br/>    location                       = optional(string, null)<br/>    transaction_log_retention_days = optional(string, "7")<br/>    retained_backups               = optional(number, 14)<br/>    retention_unit                 = optional(string, "COUNT")<br/>  })</pre> | `{}` | no |
 | <a name="input_database_deletion_protection"></a> [database\_deletion\_protection](#input\_database\_deletion\_protection) | Enable deletion protection on the Cloud SQL instance. | `bool` | `true` | no |
+| <a name="input_database_edition"></a> [database\_edition](#input\_database\_edition) | Cloud SQL edition: ENTERPRISE or ENTERPRISE\_PLUS. ENTERPRISE supports db-custom-* tiers; ENTERPRISE\_PLUS requires db-perf-optimized-N-* tiers. | `string` | `"ENTERPRISE"` | no |
 | <a name="input_database_instance_connection_name"></a> [database\_instance\_connection\_name](#input\_database\_instance\_connection\_name) | Existing Cloud SQL instance connection name (project:region:instance). Required when create\_database = false. | `string` | `null` | no |
 | <a name="input_database_instance_name"></a> [database\_instance\_name](#input\_database\_instance\_name) | Name for the Cloud SQL instance. | `string` | `"ipam-mysql"` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | MySQL database name. | `string` | `"ipam"` | no |
-| <a name="input_database_tier"></a> [database\_tier](#input\_database\_tier) | Cloud SQL machine tier (e.g. db-f1-micro, db-n1-standard-1). | `string` | `"db-f1-micro"` | no |
+| <a name="input_database_tier"></a> [database\_tier](#input\_database\_tier) | Cloud SQL machine tier (e.g. db-f1-micro, db-custom-2-3840, db-perf-optimized-N-2). | `string` | `"db-f1-micro"` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | MySQL version for the Cloud SQL instance (e.g. MYSQL\_8\_0, MYSQL\_8\_4). | `string` | `"MYSQL_8_4"` | no |
 | <a name="input_db_collation"></a> [db\_collation](#input\_db\_collation) | The collation value. | `string` | `"utf8mb3_general_ci"` | no |
 | <a name="input_disable_database_migration"></a> [disable\_database\_migration](#input\_disable\_database\_migration) | Set to true to skip automatic database migration on startup. | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | Container image for the IPAM Autopilot backend. | `string` | `"ghcr.io/boozt-platform/ipam-autopilot:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all resources (Cloud Run service, Cloud SQL instance). | `map(string)` | `{}` | no |
+| <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | (Optional) A list of external resources the module depends\_on. | `any` | `[]` | no |
+| <a name="input_module_enabled"></a> [module\_enabled](#input\_module\_enabled) | (Optional) Whether to create resources within the module or not. | `bool` | `true` | no |
 | <a name="input_network"></a> [network](#input\_network) | VPC network name or self\_link to use. Defaults to the project's default VPC. | `string` | `"default"` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | GCP organization ID used for Cloud Asset Inventory integration (IPAM\_CAI\_ORG\_ID). Leave empty to disable CAI. | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID to deploy IPAM Autopilot into. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP region for all resources. | `string` | `"europe-west1"` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | VPC subnetwork name to use for Cloud Run VPC access. Defaults to the network name when not set. | `string` | `null` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | GCP zone for the Cloud SQL instance (e.g. europe-west1-b). | `string` | `"europe-west1-b"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cloud_run_url"></a> [cloud\_run\_url](#output\_cloud\_run\_url) | IPAM Autopilot Cloud Run service URL. |
 | <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL instance connection name (project:region:instance). |
+| <a name="output_module_id"></a> [module\_id](#output\_module\_id) | Composite reference to all key module resources. Reference this output to create an explicit dependency on the module completing (e.g. depends\_on = [module.ipam.module\_id]). |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Service account email used by the IPAM Autopilot service. |
+| <a name="output_service_url"></a> [service\_url](#output\_service\_url) | IPAM Autopilot Cloud Run service URL. |
 <!-- END_TF_DOCS -->

--- a/modules/ipam-infra/main.tf
+++ b/modules/ipam-infra/main.tf
@@ -8,11 +8,18 @@
 
 locals {
   sa_email    = "ipam-autopilot@${var.project_id}.iam.gserviceaccount.com"
+  sa_username = split("@", local.sa_email)[0]
   db_instance = var.create_database ? module.mysql[0].instance_connection_name : var.database_instance_connection_name
   # Computed statically to avoid data source timing issues when the VPC is
   # created in the same apply as this module.
-  network_id   = "projects/${var.project_id}/global/networks/${var.network}"
-  subnetwork_name = coalesce(var.subnetwork, var.network)
+  network_id        = "projects/${var.project_id}/global/networks/${var.network}"
+  network_self_link = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/networks/${var.network}"
+  subnetwork_name   = coalesce(var.subnetwork, var.network)
+  # GRANT statement — changing this triggers the db_grant job to re-run.
+  db_grant_sql = "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, INDEX, LOCK TABLES, REFERENCES ON ${var.database_name}.* TO '${local.sa_username}'@'%';"
+  # Module-managed databases are always private (safer_mysql enforces no public IP).
+  # For existing databases (create_database = false), cloud_run_direct_vpc decides.
+  use_direct_vpc = var.create_database ? true : var.cloud_run_direct_vpc
 }
 
 resource "terraform_data" "module_depends_on" {
@@ -31,7 +38,8 @@ resource "google_project_service" "apis" {
       "sqladmin.googleapis.com",
       "servicenetworking.googleapis.com",
     ],
-    can(regex("docker\\.pkg\\.dev", var.image)) ? ["artifactregistry.googleapis.com"] : []
+    can(regex("docker\\.pkg\\.dev", var.image)) ? ["artifactregistry.googleapis.com"] : [],
+    var.create_database ? ["secretmanager.googleapis.com"] : [],
   ))
   project = var.project_id
   service = each.key
@@ -88,16 +96,32 @@ resource "google_cloud_run_v2_service_iam_member" "invoker" {
 }
 
 # ── Private Service Access (VPC peering for Cloud SQL private IP) ──────────────
+#
+# Inlined instead of using the GoogleCloudPlatform/sql-db private_service_access
+# module to avoid its data "google_compute_network" lookup, which fails during
+# plan in a fresh project before the network is created. local.network_self_link
+# is computed statically so no data source is needed.
 
-module "private_service_access" {
-  count  = var.cloud_sql_private_ip ? 1 : 0
-  source = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
-
-  project_id    = var.project_id
-  vpc_network   = var.network
+resource "google_compute_global_address" "private_service_access" {
+  count         = var.create_database ? 1 : 0
+  project       = var.project_id
+  name          = "google-managed-services-${var.network}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
   prefix_length = 16
+  network       = local.network_self_link
 
-  depends_on = [google_project_service.apis]
+  depends_on = [google_project_service.apis["servicenetworking.googleapis.com"]]
+}
+
+resource "google_service_networking_connection" "private_service_access" {
+  count                   = var.create_database ? 1 : 0
+  network                 = local.network_self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_access[0].name]
+  deletion_policy         = "ABANDON"
+
+  depends_on = [google_project_service.apis["servicenetworking.googleapis.com"]]
 }
 
 # ── Cloud SQL (safer_mysql — IAM-only auth) ────────────────────────────────────
@@ -117,7 +141,7 @@ module "mysql" {
   db_name            = var.database_name
   db_collation       = var.db_collation
   vpc_network        = local.network_id
-  allocated_ip_range = var.cloud_sql_private_ip ? module.private_service_access[0].google_compute_global_address_name : null
+  allocated_ip_range = google_compute_global_address.private_service_access[0].name
 
   deletion_protection         = var.database_deletion_protection
   deletion_protection_enabled = var.database_deletion_protection
@@ -142,7 +166,7 @@ module "mysql" {
 
   backup_configuration = var.database_backup_configuration
 
-  depends_on = [module.private_service_access]
+  depends_on = [google_service_networking_connection.private_service_access]
 }
 
 # Create the IAM SQL user outside safer_mysql so its key is not in a for_each,
@@ -156,6 +180,213 @@ resource "google_sql_user" "iam_sa" {
   type     = "CLOUD_IAM_SERVICE_ACCOUNT"
 
   depends_on = [module.mysql]
+}
+
+# ── Database GRANT setup ───────────────────────────────────────────────────────
+#
+# A dedicated service account (ipam-db-setup) stores the safer_mysql default
+# user password in Secret Manager and runs a one-off Cloud Run Job that applies
+# the minimum required MySQL privileges to the IPAM service account.
+#
+# The job re-runs automatically when the privilege set changes: db_grant_sql is
+# hashed into triggers_replace, so updating the GRANT in a new module version
+# forces a new terraform_data resource → provisioner re-executes → job runs.
+#
+# Requires gcloud to be installed and authenticated in the Terraform execution
+# environment (local or CI/CD runner).
+
+resource "google_service_account" "db_setup" {
+  count        = var.create_database ? 1 : 0
+  project      = var.project_id
+  account_id   = "ipam-db-setup"
+  display_name = "IPAM Database Setup"
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_project_iam_member" "db_setup_sql_client" {
+  count   = var.create_database ? 1 : 0
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.db_setup[0].email}"
+
+  depends_on = [google_service_account.db_setup]
+}
+
+resource "google_secret_manager_secret" "db_default_password" {
+  count     = var.create_database ? 1 : 0
+  project   = var.project_id
+  secret_id = "${var.database_instance_name}-setup-password"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "db_default_password" {
+  count       = var.create_database ? 1 : 0
+  secret      = google_secret_manager_secret.db_default_password[0].id
+  secret_data = module.mysql[0].generated_user_password
+
+  depends_on = [module.mysql]
+}
+
+resource "google_secret_manager_secret_iam_member" "db_default_password_reader" {
+  count     = var.create_database ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.db_default_password[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.db_setup[0].email}"
+
+  depends_on = [google_service_account.db_setup]
+}
+
+resource "google_cloud_run_v2_job" "db_grant" {
+  count    = var.create_database ? 1 : 0
+  project  = var.project_id
+  name     = "${var.cloud_run_name}-db-grant"
+  location = var.region
+
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.db_setup[0].email
+      max_retries     = 3
+
+      dynamic "vpc_access" {
+        for_each = [1]
+        content {
+          egress = "PRIVATE_RANGES_ONLY"
+          network_interfaces {
+            network    = var.network
+            subnetwork = local.subnetwork_name
+          }
+        }
+      }
+
+      volumes {
+        name = "cloudsql-socket"
+        empty_dir {
+          medium     = "MEMORY"
+          size_limit = "32Mi"
+        }
+      }
+
+      containers {
+        name  = "cloudsql-proxy"
+        image = var.cloud_sql_proxy_image
+        args = [
+          "--private-ip",
+          "--unix-socket=/cloudsql",
+          "--exit-zero-on-sigterm",
+          "--health-check",
+          "--http-address=0.0.0.0",
+          local.db_instance,
+        ]
+        volume_mounts {
+          name       = "cloudsql-socket"
+          mount_path = "/cloudsql"
+        }
+        startup_probe {
+          period_seconds    = 1
+          failure_threshold = 60
+          http_get {
+            path = "/startup"
+            port = 9090
+          }
+        }
+      }
+
+      containers {
+        name       = "mysql-grant"
+        image      = "docker.io/library/mysql:8.4"
+        depends_on = ["cloudsql-proxy"]
+        command    = ["/bin/sh", "-c"]
+        args = [
+          "mysql --socket=/cloudsql/${local.db_instance} -u default --password=\"$DB_PASSWORD\" -e \"${local.db_grant_sql}\""
+        ]
+        env {
+          name = "DB_PASSWORD"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.db_default_password[0].secret_id
+              version = "latest"
+            }
+          }
+        }
+        volume_mounts {
+          name       = "cloudsql-socket"
+          mount_path = "/cloudsql"
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_iam_member.db_setup_sql_client,
+    google_secret_manager_secret_iam_member.db_default_password_reader,
+    google_secret_manager_secret_version.db_default_password,
+  ]
+}
+
+data "google_client_config" "default" {}
+
+resource "terraform_data" "run_db_grant" {
+  count = var.create_database ? 1 : 0
+
+  # Re-runs the job when the privilege set changes.
+  triggers_replace = sha256(local.db_grant_sql)
+
+  provisioner "local-exec" {
+    environment = {
+      TOKEN   = data.google_client_config.default.access_token
+      PROJECT = var.project_id
+      REGION  = var.region
+      JOB     = google_cloud_run_v2_job.db_grant[0].name
+    }
+    command = <<-EOT
+      set -e
+      RESPONSE=$(curl -sf -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        "https://run.googleapis.com/v2/projects/$PROJECT/locations/$REGION/jobs/$JOB:run")
+
+      OP=$(echo "$RESPONSE" | tr -d ' \n' | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4)
+      if [ -z "$OP" ]; then
+        echo "Failed to parse operation name from response." >&2
+        exit 1
+      fi
+      echo "Waiting for operation: $OP"
+
+      for i in $(seq 1 30); do
+        STATUS=$(curl -sf \
+          -H "Authorization: Bearer $TOKEN" \
+          "https://run.googleapis.com/v2/$OP")
+        COMPACT=$(echo "$STATUS" | tr -d ' \n')
+        if echo "$COMPACT" | grep -q '"done":true'; then
+          if echo "$COMPACT" | grep -q '"error"'; then
+            echo "GRANT job failed." >&2
+            exit 1
+          fi
+          echo "GRANT job completed."
+          exit 0
+        fi
+        echo "Attempt $i/30, retrying in 10s..."
+        sleep 10
+      done
+
+      echo "Timeout waiting for GRANT job." >&2
+      exit 1
+    EOT
+  }
+
+  depends_on = [
+    google_cloud_run_v2_job.db_grant,
+    google_sql_user.iam_sa,
+  ]
 }
 
 # ── Cloud Run v2 ───────────────────────────────────────────────────────────────
@@ -177,7 +408,7 @@ resource "google_cloud_run_v2_service" "ipam" {
     }
 
     dynamic "vpc_access" {
-      for_each = var.cloud_sql_private_ip ? [1] : []
+      for_each = local.use_direct_vpc ? [1] : []
       content {
         egress = "PRIVATE_RANGES_ONLY"
         network_interfaces {
@@ -200,14 +431,16 @@ resource "google_cloud_run_v2_service" "ipam" {
     containers {
       name  = "cloudsql-proxy"
       image = var.cloud_sql_proxy_image
-      args = [
-        "--auto-iam-authn",
-        "--private-ip",
-        "--unix-socket=/cloudsql",
-        "--health-check",
-        "--http-address=0.0.0.0",
-        local.db_instance,
-      ]
+      args = concat(
+        local.use_direct_vpc ? ["--private-ip"] : [],
+        [
+          "--auto-iam-authn",
+          "--unix-socket=/cloudsql",
+          "--health-check",
+          "--http-address=0.0.0.0",
+          local.db_instance,
+        ]
+      )
       volume_mounts {
         name       = "cloudsql-socket"
         mount_path = "/cloudsql"
@@ -238,7 +471,7 @@ resource "google_cloud_run_v2_service" "ipam" {
       }
       env {
         name  = "IPAM_DATABASE_USER"
-        value = split("@", local.sa_email)[0]
+        value = local.sa_username
       }
       env {
         name  = "IPAM_DATABASE_NAME"
@@ -272,6 +505,7 @@ resource "google_cloud_run_v2_service" "ipam" {
   depends_on = [
     google_project_iam_member.sql_client,
     google_project_iam_member.sql_instance_user,
-    module.mysql, # no-op when create_database = false
+    module.mysql,                # no-op when create_database = false
+    terraform_data.run_db_grant, # no-op when create_database = false
   ]
 }

--- a/modules/ipam-infra/main.tf
+++ b/modules/ipam-infra/main.tf
@@ -7,8 +7,16 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 
 locals {
-  sa_email    = google_service_account.ipam.email
+  sa_email    = "ipam-autopilot@${var.project_id}.iam.gserviceaccount.com"
   db_instance = var.create_database ? module.mysql[0].instance_connection_name : var.database_instance_connection_name
+  # Computed statically to avoid data source timing issues when the VPC is
+  # created in the same apply as this module.
+  network_id   = "projects/${var.project_id}/global/networks/${var.network}"
+  subnetwork_name = coalesce(var.subnetwork, var.network)
+}
+
+resource "terraform_data" "module_depends_on" {
+  input = var.module_depends_on
 }
 
 # ── APIs ───────────────────────────────────────────────────────────────────────
@@ -29,11 +37,8 @@ resource "google_project_service" "apis" {
   service = each.key
 
   disable_on_destroy = false
-}
 
-data "google_compute_network" "vpc" {
-  name    = var.network
-  project = var.project_id
+  depends_on = [terraform_data.module_depends_on]
 }
 
 # ── Service Account ────────────────────────────────────────────────────────────
@@ -52,12 +57,16 @@ resource "google_project_iam_member" "sql_client" {
   project = var.project_id
   role    = "roles/cloudsql.client"
   member  = "serviceAccount:${local.sa_email}"
+
+  depends_on = [google_service_account.ipam]
 }
 
 resource "google_project_iam_member" "sql_instance_user" {
   project = var.project_id
   role    = "roles/cloudsql.instanceUser"
   member  = "serviceAccount:${local.sa_email}"
+
+  depends_on = [google_service_account.ipam]
 }
 
 resource "google_organization_iam_member" "cai_viewer" {
@@ -65,6 +74,8 @@ resource "google_organization_iam_member" "cai_viewer" {
   org_id = var.organization_id
   role   = "roles/cloudasset.viewer"
   member = "serviceAccount:${local.sa_email}"
+
+  depends_on = [google_service_account.ipam]
 }
 
 resource "google_cloud_run_v2_service_iam_member" "invoker" {
@@ -83,7 +94,7 @@ module "private_service_access" {
   source = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
 
   project_id    = var.project_id
-  vpc_network   = data.google_compute_network.vpc.name
+  vpc_network   = var.network
   prefix_length = 16
 
   depends_on = [google_project_service.apis]
@@ -105,7 +116,7 @@ module "mysql" {
   edition            = var.database_edition
   db_name            = var.database_name
   db_collation       = var.db_collation
-  vpc_network        = data.google_compute_network.vpc.id
+  vpc_network        = local.network_id
   allocated_ip_range = var.cloud_sql_private_ip ? module.private_service_access[0].google_compute_global_address_name : null
 
   deletion_protection         = var.database_deletion_protection
@@ -127,16 +138,24 @@ module "mysql" {
     },
   ]
 
-  iam_users = [
-    {
-      id    = trimsuffix(local.sa_email, ".gserviceaccount.com")
-      email = local.sa_email
-    }
-  ]
+  iam_users = []
 
   backup_configuration = var.database_backup_configuration
 
   depends_on = [module.private_service_access]
+}
+
+# Create the IAM SQL user outside safer_mysql so its key is not in a for_each,
+# which would fail at plan time when project_id is not yet known (e.g. when the
+# GCP project itself is created in the same apply).
+resource "google_sql_user" "iam_sa" {
+  count    = var.create_database ? 1 : 0
+  project  = var.project_id
+  instance = module.mysql[0].instance_name
+  name     = local.sa_email
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+
+  depends_on = [module.mysql]
 }
 
 # ── Cloud Run v2 ───────────────────────────────────────────────────────────────
@@ -162,7 +181,8 @@ resource "google_cloud_run_v2_service" "ipam" {
       content {
         egress = "PRIVATE_RANGES_ONLY"
         network_interfaces {
-          network = data.google_compute_network.vpc.name
+          network    = var.network
+          subnetwork = local.subnetwork_name
         }
       }
     }

--- a/modules/ipam-infra/outputs.tf
+++ b/modules/ipam-infra/outputs.tf
@@ -6,7 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-output "cloud_run_url" {
+output "service_url" {
   description = "IPAM Autopilot Cloud Run service URL."
   value       = google_cloud_run_v2_service.ipam.uri
 }
@@ -19,4 +19,13 @@ output "service_account_email" {
 output "database_instance_connection_name" {
   description = "Cloud SQL instance connection name (project:region:instance)."
   value       = local.db_instance
+}
+
+output "module_id" {
+  description = "Composite reference to all key module resources. Reference this output to create an explicit dependency on the module completing (e.g. depends_on = [module.ipam.module_id])."
+  value = {
+    service_url    = google_cloud_run_v2_service.ipam.uri
+    sa_email       = google_service_account.ipam.email
+    db_connection  = local.db_instance
+  }
 }

--- a/modules/ipam-infra/tests/unit_test.tftest.hcl
+++ b/modules/ipam-infra/tests/unit_test.tftest.hcl
@@ -28,8 +28,30 @@ run "enables_required_apis" {
       "cloudasset.googleapis.com",
       "sqladmin.googleapis.com",
       "servicenetworking.googleapis.com",
+      "secretmanager.googleapis.com",
     ])
-    error_message = "Should enable exactly the 6 required GCP APIs."
+    error_message = "Should enable 7 required GCP APIs (secretmanager included when create_database=true)."
+  }
+}
+
+run "enables_required_apis_without_database" {
+  command = plan
+
+  variables {
+    create_database                   = false
+    database_instance_connection_name = "test-project:europe-west1:existing-ipam"
+  }
+
+  assert {
+    condition = toset(keys(google_project_service.apis)) == toset([
+      "iam.googleapis.com",
+      "run.googleapis.com",
+      "compute.googleapis.com",
+      "cloudasset.googleapis.com",
+      "sqladmin.googleapis.com",
+      "servicenetworking.googleapis.com",
+    ])
+    error_message = "Should enable 6 APIs (no secretmanager) when create_database=false."
   }
 }
 
@@ -190,29 +212,36 @@ run "database_edition_invalid_value_rejected" {
 
 # ── Private Service Access ────────────────────────────────────────────────────
 
-run "private_service_access_created_with_private_ip" {
+run "private_service_access_created_when_database_created" {
   command = plan
 
-  variables {
-    cloud_sql_private_ip = true
+  assert {
+    condition     = length(google_compute_global_address.private_service_access) == 1
+    error_message = "Should create PSA global address when create_database=true."
   }
 
   assert {
-    condition     = length(module.private_service_access) == 1
-    error_message = "Should create private service access when cloud_sql_private_ip=true."
+    condition     = length(google_service_networking_connection.private_service_access) == 1
+    error_message = "Should create service networking connection when create_database=true."
   }
 }
 
-run "private_service_access_skipped_without_private_ip" {
+run "private_service_access_skipped_without_database" {
   command = plan
 
   variables {
-    cloud_sql_private_ip = false
+    create_database                   = false
+    database_instance_connection_name = "test-project:europe-west1:existing-ipam"
   }
 
   assert {
-    condition     = length(module.private_service_access) == 0
-    error_message = "Should skip private service access when cloud_sql_private_ip=false."
+    condition     = length(google_compute_global_address.private_service_access) == 0
+    error_message = "Should skip PSA global address when create_database=false."
+  }
+
+  assert {
+    condition     = length(google_service_networking_connection.private_service_access) == 0
+    error_message = "Should skip service networking connection when create_database=false."
   }
 }
 
@@ -220,10 +249,6 @@ run "private_service_access_skipped_without_private_ip" {
 
 run "subnetwork_defaults_to_network_name" {
   command = plan
-
-  variables {
-    cloud_sql_private_ip = true
-  }
 
   assert {
     condition     = google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].subnetwork == google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].network
@@ -235,12 +260,117 @@ run "subnetwork_explicit_value_used" {
   command = plan
 
   variables {
-    cloud_sql_private_ip = true
-    subnetwork           = "my-custom-subnet"
+    subnetwork = "my-custom-subnet"
   }
 
   assert {
     condition     = google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].subnetwork == "my-custom-subnet"
     error_message = "subnetwork should use the explicitly provided value."
+  }
+}
+
+# ── Database GRANT job ────────────────────────────────────────────────────────
+
+run "db_grant_resources_created_with_database" {
+  command = plan
+
+  assert {
+    condition     = length(google_service_account.db_setup) == 1
+    error_message = "Should create db_setup service account when create_database=true."
+  }
+
+  assert {
+    condition     = google_service_account.db_setup[0].account_id == "ipam-db-setup"
+    error_message = "db_setup service account ID should be ipam-db-setup."
+  }
+
+  assert {
+    condition     = length(google_secret_manager_secret.db_default_password) == 1
+    error_message = "Should create Secret Manager secret when create_database=true."
+  }
+
+  assert {
+    condition     = length(google_cloud_run_v2_job.db_grant) == 1
+    error_message = "Should create db_grant Cloud Run Job when create_database=true."
+  }
+}
+
+run "db_grant_resources_skipped_without_database" {
+  command = plan
+
+  variables {
+    create_database                   = false
+    database_instance_connection_name = "test-project:europe-west1:existing-ipam"
+  }
+
+  assert {
+    condition     = length(google_service_account.db_setup) == 0
+    error_message = "Should not create db_setup service account when create_database=false."
+  }
+
+  assert {
+    condition     = length(google_secret_manager_secret.db_default_password) == 0
+    error_message = "Should not create Secret Manager secret when create_database=false."
+  }
+
+  assert {
+    condition     = length(google_cloud_run_v2_job.db_grant) == 0
+    error_message = "Should not create db_grant Cloud Run Job when create_database=false."
+  }
+}
+
+run "db_grant_job_name_includes_cloud_run_name" {
+  command = plan
+
+  variables {
+    cloud_run_name = "my-ipam"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_job.db_grant[0].name == "my-ipam-db-grant"
+    error_message = "db_grant job name should be <cloud_run_name>-db-grant."
+  }
+}
+
+run "db_grant_job_always_uses_vpc_access" {
+  command = plan
+
+  variables {
+    subnetwork = "my-subnet"
+  }
+
+  assert {
+    condition     = length(google_cloud_run_v2_job.db_grant[0].template[0].template[0].vpc_access) == 1
+    error_message = "db_grant job should always have VPC access (database is always private)."
+  }
+}
+
+run "cloud_run_no_vpc_access_when_existing_db_public" {
+  command = plan
+
+  variables {
+    create_database                   = false
+    database_instance_connection_name = "test-project:europe-west1:existing-ipam"
+    cloud_run_direct_vpc              = false
+  }
+
+  assert {
+    condition     = length(google_cloud_run_v2_service.ipam.template[0].vpc_access) == 0
+    error_message = "Cloud Run should have no VPC access when create_database=false and cloud_run_direct_vpc=false."
+  }
+}
+
+run "cloud_run_vpc_access_when_existing_db_private" {
+  command = plan
+
+  variables {
+    create_database                   = false
+    database_instance_connection_name = "test-project:europe-west1:existing-ipam"
+    cloud_run_direct_vpc              = true
+  }
+
+  assert {
+    condition     = length(google_cloud_run_v2_service.ipam.template[0].vpc_access) == 1
+    error_message = "Cloud Run should have VPC access when create_database=false and cloud_run_direct_vpc=true."
   }
 }

--- a/modules/ipam-infra/tests/unit_test.tftest.hcl
+++ b/modules/ipam-infra/tests/unit_test.tftest.hcl
@@ -6,13 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-mock_provider "google" {
-  mock_data "google_compute_network" {
-    defaults = {
-      id = "projects/test-project/global/networks/default"
-    }
-  }
-}
+mock_provider "google" {}
 
 # google-beta is used internally by some GoogleCloudPlatform modules
 mock_provider "google-beta" {}
@@ -219,5 +213,34 @@ run "private_service_access_skipped_without_private_ip" {
   assert {
     condition     = length(module.private_service_access) == 0
     error_message = "Should skip private service access when cloud_sql_private_ip=false."
+  }
+}
+
+# ── Subnetwork ────────────────────────────────────────────────────────────────
+
+run "subnetwork_defaults_to_network_name" {
+  command = plan
+
+  variables {
+    cloud_sql_private_ip = true
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].subnetwork == google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].network
+    error_message = "subnetwork should default to the network name when not set."
+  }
+}
+
+run "subnetwork_explicit_value_used" {
+  command = plan
+
+  variables {
+    cloud_sql_private_ip = true
+    subnetwork           = "my-custom-subnet"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.ipam.template[0].vpc_access[0].network_interfaces[0].subnetwork == "my-custom-subnet"
+    error_message = "subnetwork should use the explicitly provided value."
   }
 }

--- a/modules/ipam-infra/variables.tf
+++ b/modules/ipam-infra/variables.tf
@@ -54,8 +54,8 @@ variable "subnetwork" {
   default     = null
 }
 
-variable "cloud_sql_private_ip" {
-  description = "Use private IP for Cloud SQL. Requires VPC peering with servicenetworking. Recommended for production."
+variable "cloud_run_direct_vpc" {
+  description = "Connect Cloud Run to the VPC using Direct VPC egress. Required when the Cloud SQL instance is on a private IP. Only relevant when create_database = false; when create_database = true the database is always private and Direct VPC is always enabled."
   type        = bool
   default     = true
 }

--- a/modules/ipam-infra/variables.tf
+++ b/modules/ipam-infra/variables.tf
@@ -48,6 +48,12 @@ variable "network" {
   default     = "default"
 }
 
+variable "subnetwork" {
+  description = "VPC subnetwork name to use for Cloud Run VPC access. Defaults to the network name when not set."
+  type        = string
+  default     = null
+}
+
 variable "cloud_sql_private_ip" {
   description = "Use private IP for Cloud SQL. Requires VPC peering with servicenetworking. Recommended for production."
   type        = bool
@@ -189,6 +195,20 @@ variable "disable_database_migration" {
   description = "Set to true to skip automatic database migration on startup."
   type        = bool
   default     = false
+}
+
+# ── Dependencies ──────────────────────────────────────────────────────────────
+
+variable "module_enabled" {
+  description = "(Optional) Whether to create resources within the module or not."
+  type        = bool
+  default     = true
+}
+
+variable "module_depends_on" {
+  description = "(Optional) A list of external resources the module depends_on."
+  type        = any
+  default     = []
 }
 
 # ── Labels ─────────────────────────────────────────────────────────────────────

--- a/modules/ipam-network/README.md
+++ b/modules/ipam-network/README.md
@@ -6,7 +6,7 @@ Registers a VPC network and its top-level IP blocks in IPAM Autopilot. Creates a
 
 ```hcl
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.13.1"
 
   domain = "prod-vpc"
   labels = { env = "prod" }
@@ -39,6 +39,8 @@ resource "ipam_ip_range" "my_team" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain"></a> [domain](#input\_domain) | Routing domain definition. name is the domain identifier (e.g. "prod-vpc"); cidr is the root address space allocated to it (e.g. "10.0.0.0/8"). | <pre>object({<br/>    name = string<br/>    cidr = string<br/>  })</pre> | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels applied to all resources. Per-network labels override these when set. | `map(string)` | `{}` | no |
+| <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | (Optional) A list of external resources the module depends\_on. | `any` | `[]` | no |
+| <a name="input_module_enabled"></a> [module\_enabled](#input\_module\_enabled) | (Optional) Whether to create resources within the module or not. | `bool` | `true` | no |
 | <a name="input_networks"></a> [networks](#input\_networks) | Map of network blocks to carve from the domain's root CIDR. Key is the block name; size is the prefix length. labels overrides the module-level labels when set. | <pre>map(object({<br/>    size   = number<br/>    labels = optional(map(string))<br/>  }))</pre> | `{}` | no |
 
 ## Outputs

--- a/modules/ipam-network/main.tf
+++ b/modules/ipam-network/main.tf
@@ -6,8 +6,14 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+resource "terraform_data" "module_depends_on" {
+  input = var.module_depends_on
+}
+
 resource "ipam_routing_domain" "this" {
   name = var.domain.name
+
+  depends_on = [terraform_data.module_depends_on]
 }
 
 resource "ipam_ip_range" "root" {

--- a/modules/ipam-network/providers.tf
+++ b/modules/ipam-network/providers.tf
@@ -11,7 +11,8 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.11"
+      version = "~> 1.13"
     }
   }
 }
+

--- a/modules/ipam-network/variables.tf
+++ b/modules/ipam-network/variables.tf
@@ -43,3 +43,15 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "module_enabled" {
+  description = "(Optional) Whether to create resources within the module or not."
+  type        = bool
+  default     = true
+}
+
+variable "module_depends_on" {
+  description = "(Optional) A list of external resources the module depends_on."
+  type        = any
+  default     = []
+}

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.11.0"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.11"
+      version = "~> 1.13"
     }
   }
 }


### PR DESCRIPTION
   ## Summary

   - Added `subnetwork`, `module_depends_on`, `module_id`, `database_edition`, `cloud_run_direct_vpc` variables to `ipam-infra`; renamed `cloud_run_url` output to `service_url`
   - Replaced `cloud_sql_private_ip` with `cloud_run_direct_vpc`: Cloud SQL is always private when `create_database = true` (enforced by `safer_mysql`); the new variable only applies when `create_database = false` to control Cloud Run Direct VPC egress
   - Inlined `private_service_access` submodule as direct resources to fix plan-time data source failure in fresh GCP projects where the VPC does not yet exist
   - Added `module_depends_on` and `module_enabled` to `ipam-network`
   - Rewrote `examples/sandbox-gcp-vpc` to create a full GCP project from scratch; added `folder_id` variable and fixed `google_project` to accept either `org_id` or `folder_id`
   - Added `examples/sandbox-network` for registering VPC domains and network blocks
   - Documented GCP 1-2 hour `serverless-ipv4-*` address release delay with teardown guidance
   - Fixed `sed -i` macOS incompatibility in `make docs` target


Closes #30 