### PR TITLE
chore: update version references to v1.15.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,17 @@
 
 | Path | What it is |
 |---|---|
-| `container/` | Go backend — Fiber HTTP server, MySQL, Cloud Asset Inventory |
+| `container/` | Go backend: Fiber HTTP server, MySQL, Cloud Asset Inventory |
 | `provider/` | Terraform/OpenTofu provider (terraform-plugin-sdk v2) |
-| `modules/ipam-infra/` | Terraform module — deploys backend to GCP (Cloud Run + Cloud SQL) |
-| `modules/ipam-network/` | Terraform module — registers a VPC domain and network blocks |
+| `modules/ipam-infra/` | Terraform module: deploys backend to GCP (Cloud Run + Cloud SQL) |
+| `modules/ipam-network/` | Terraform module: registers a VPC domain and network blocks |
 | `examples/` | Working usage examples |
-| `docs/` | Generated provider docs (OpenTofu registry format) — do not edit directly |
-| `provider/templates/` | Source templates for `docs/` — edit these, not `docs/` |
+| `docs/` | Generated provider docs (OpenTofu registry format). Do not edit directly. |
+| `provider/templates/` | Source templates for `docs/`. Edit these, not `docs/`. |
 
 ## Dev environment
 
-The easiest way is to open the repo in VS Code — the [devcontainer](./.devcontainer) includes Go, OpenTofu, golangci-lint, hadolint, terraform-docs, and gcloud.
+The easiest way is to open the repo in VS Code. The [devcontainer](./.devcontainer) includes Go, OpenTofu, golangci-lint, hadolint, terraform-docs, and gcloud.
 
 For manual setup you need: Go 1.22+, OpenTofu or Terraform, Docker, golangci-lint, hadolint.
 
@@ -54,11 +54,11 @@ make dev-destroy  # tears it down
 
 ```bash
 make test                # Go unit tests (container + provider) + HCL module tests
-make test-integration    # integration tests via testcontainers — requires Docker
+make test-integration    # integration tests via testcontainers (requires Docker)
 make test-modules        # HCL unit tests only, using locally built provider binary
 ```
 
-HCL module tests live in `modules/*/tests/unit_test.tftest.hcl`. They always run against the locally built provider binary — never the published registry version. Do not run `tofu test` directly in a module directory without the dev override.
+HCL module tests live in `modules/*/tests/unit_test.tftest.hcl`. They always run against the locally built provider binary, not the published registry version. Do not run `tofu test` directly in a module directory without the dev override.
 
 Write or update tests for every change before running the gate.
 
@@ -68,7 +68,7 @@ Write or update tests for every change before running the gate.
 make check
 ```
 
-Runs lint (golangci-lint + hadolint) + format (gofmt) + tests + build + docs. Fix every failure before committing — do not suppress linter warnings without a documented reason.
+Runs lint (golangci-lint + hadolint) + format (gofmt) + tests + build + docs. Fix every failure before committing. Do not suppress linter warnings without a documented reason.
 
 ## Commit conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing
+
+## Repo layout
+
+| Path | What it is |
+|---|---|
+| `container/` | Go backend — Fiber HTTP server, MySQL, Cloud Asset Inventory |
+| `provider/` | Terraform/OpenTofu provider (terraform-plugin-sdk v2) |
+| `modules/ipam-infra/` | Terraform module — deploys backend to GCP (Cloud Run + Cloud SQL) |
+| `modules/ipam-network/` | Terraform module — registers a VPC domain and network blocks |
+| `examples/` | Working usage examples |
+| `docs/` | Generated provider docs (OpenTofu registry format) — do not edit directly |
+| `provider/templates/` | Source templates for `docs/` — edit these, not `docs/` |
+
+## Dev environment
+
+The easiest way is to open the repo in VS Code — the [devcontainer](./.devcontainer) includes Go, OpenTofu, golangci-lint, hadolint, terraform-docs, and gcloud.
+
+For manual setup you need: Go 1.22+, OpenTofu or Terraform, Docker, golangci-lint, hadolint.
+
+## Running the stack locally
+
+```bash
+docker compose up --build -d
+```
+
+Starts MySQL + the IPAM API at `localhost:8080` and Jaeger at `localhost:16686`.
+
+To test the Terraform provider against the local stack:
+
+```bash
+make dev-apply    # builds provider, applies examples/local-dev
+make dev-destroy  # tears it down
+```
+
+## Making changes
+
+### Backend (Go)
+
+| What changed | Files to edit |
+|---|---|
+| New API endpoint | `container/server/api.go` (handler) + `container/server/data_access.go` (DB) + `container/server/server.go` (route) |
+| DB schema change | Add a migration file in `container/server/migrations/` |
+| Provider resource | `provider/ipam/resources/resource_ip_range.go` or `resource_routing_domain.go` |
+
+### Terraform modules
+
+| Module | Main file |
+|---|---|
+| `ipam-infra` | `modules/ipam-infra/main.tf` |
+| `ipam-network` | `modules/ipam-network/main.tf` |
+
+## Testing
+
+```bash
+make test                # Go unit tests (container + provider) + HCL module tests
+make test-integration    # integration tests via testcontainers — requires Docker
+make test-modules        # HCL unit tests only, using locally built provider binary
+```
+
+HCL module tests live in `modules/*/tests/unit_test.tftest.hcl`. They always run against the locally built provider binary — never the published registry version. Do not run `tofu test` directly in a module directory without the dev override.
+
+Write or update tests for every change before running the gate.
+
+## Pre-commit gate
+
+```bash
+make check
+```
+
+Runs lint (golangci-lint + hadolint) + format (gofmt) + tests + build + docs. Fix every failure before committing — do not suppress linter warnings without a documented reason.
+
+## Commit conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). go-semantic-release derives the version from commit prefixes automatically on merge to `main`.
+
+| Prefix | Version bump | When to use |
+|---|---|---|
+| `feat:` | minor | new capability visible to users |
+| `fix:` | patch | bug fix |
+| `docs:` | none | documentation only |
+| `test:` | none | tests only |
+| `chore:` | none | tooling, CI, dependencies |
+
+Commit related files in logical groups. Reference issues with `Closes #N` in the commit body.
+
+## After a release
+
+When go-semantic-release creates a new tag on `main`:
+
+```bash
+git checkout main && git pull
+make update-version VERSION=vX.Y.Z
+make docs
+make docs-modules
+git commit -am "chore: update version references to vX.Y.Z"
+```

--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,10 @@ update-version: ## Update all version references (usage: make update-version VER
 		-not -path "*/.git/*" \
 		| xargs perl -pi -e \
 		's|\?ref=v[0-9]+\.[0-9]+\.[0-9]+|?ref=$(VERSION)|g'
-	@# Update provider version constraint only in files that reference boozt-platform/ipam-autopilot
+	@# Update provider version constraint only in the ipam-autopilot provider block
 	@grep -rl 'boozt-platform/ipam-autopilot' $(REPO_ROOT) \
 		--include="*.tf" --include="*.md" --include="*.md.tmpl" \
 		--exclude-dir=".terraform" --exclude-dir=".git" \
-		| xargs perl -pi -e \
-		's|version = "~> [0-9]+\.[0-9]+"|version = "~> $(MINOR)"|g'
+		| xargs perl -0777 -pi -e \
+		's|(source\s*=\s*"boozt-platform/ipam-autopilot"[^}]*?version\s*=\s*)"~> [0-9]+\.[0-9]+"|\1"~> $(MINOR)"|gs'
 	@echo "Done. Run 'make docs && make docs-modules' to regenerate docs."

--- a/README.md
+++ b/README.md
@@ -1,63 +1,41 @@
 # IPAM Autopilot
 
 > **Fork notice:** This is a Boozt Fashion AB fork of
-> [GoogleCloudPlatform/professional-services](https://github.com/GoogleCloudPlatform/professional-services/tree/main/tools/ipam-autopilot),
-> maintained at [boozt-platform/ipam-autopilot](https://github.com/boozt-platform/ipam-autopilot).
+> [GoogleCloudPlatform/professional-services](https://github.com/GoogleCloudPlatform/professional-services/tree/main/tools/ipam-autopilot).
 > See [NOTICE](./NOTICE) and [CHANGES.md](./CHANGES.md) for details.
 
-IPAM Autopilot automatically manages IP ranges for GCP VPCs. It provides a REST API backend deployed on Cloud Run and a Terraform provider for IaC-driven CIDR allocation.
-
-It integrates with Cloud Asset Inventory to discover existing subnets and prevent overlap, even for ranges not registered in IPAM.
+IPAM Autopilot manages IP address space for GCP VPCs via a REST API and a Terraform provider. It auto-allocates non-overlapping CIDRs and integrates with Cloud Asset Inventory to avoid conflicts with subnets that exist outside of IPAM.
 
 ![Architecture showing Terraform, CloudRun, CloudSQL and Cloud Asset Inventory](./img/architecture.png "IPAM Autopilot Architecture")
 
 ---
 
-## Deploying the backend
+## Getting started
 
-Use the `modules/ipam-infra` Terraform module to deploy the IPAM backend to GCP:
+### 1. Deploy the backend
+
+Deploy the IPAM backend (Cloud Run + Cloud SQL) into your GCP project:
 
 ```hcl
 module "ipam" {
   source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.15.0"
 
-  project_id      = "my-project"
-  region          = "europe-west1"
-  organization_id = "123456789"   # optional — enables CAI integration
-
-  image = "ghcr.io/boozt-platform/ipam-autopilot:latest"  # or booztpl/ipam-autopilot:latest
+  project_id = "my-project"
+  region     = "europe-west1"
+  network    = "my-vpc"
+  subnetwork = "my-ipam-subnet"
 }
 
 output "ipam_url" {
-  value = module.ipam.cloud_run_url
+  value = module.ipam.service_url
 }
 ```
 
-See [`modules/ipam-infra`](./modules/ipam-infra) for all available variables.
+For a full working example including project and VPC creation see [`examples/sandbox-gcp-vpc`](./examples/sandbox-gcp-vpc).
 
-### Key module variables
+### 2. Register a network
 
-| Variable | Default | Description |
-|---|---|---|
-| `project_id` | | GCP project to deploy into |
-| `region` | `europe-west1` | GCP region |
-| `organization_id` | `""` | Org ID for Cloud Asset Inventory (leave empty to disable) |
-| `image` | `ghcr.io/boozt-platform/ipam-autopilot:latest` | Container image |
-| `database_tier` | `db-f1-micro` | Cloud SQL machine type |
-| `database_deletion_protection` | `true` | Protect database from accidental deletion |
-| `cloud_run_ingress` | `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` | Cloud Run ingress setting |
-| `cloud_run_allow_unauthenticated` | `false` | Allow unauthenticated access (enable for testing only) |
-| `cloud_sql_proxy_image` | `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.21.2` | Cloud SQL Auth Proxy version |
-
-### Examples
-
-- [`examples/infra`](./examples/infra) — full sandbox deployment with public access for testing
-
----
-
-## Registering a network
-
-Use the `modules/ipam-network` module to register a VPC network and its top-level IP blocks:
+Register a VPC and allocate CIDR blocks using the Terraform provider:
 
 ```hcl
 terraform {
@@ -70,7 +48,7 @@ terraform {
 }
 
 provider "ipam" {
-  url = "https://your-ipam-cloud-run-url"
+  url = "https://your-ipam-url"  # or set IPAM_URL env var
 }
 
 module "prod_network" {
@@ -80,258 +58,28 @@ module "prod_network" {
     name = "prod-vpc"
     cidr = "10.0.0.0/8"
   }
-  labels = { env = "prod" }
 
   networks = {
-    "tenant"       = { size = 16 }
     "gke-nodes"    = { size = 16 }
-    "gke-pods"     = { size = 16 }
-    "gke-services" = { size = 16 }
+    "gke-services" = { size = 24 }
+    "tenant"       = { size = 16 }
   }
 }
-
-# Allocate a tenant subnet from the tenant block
-resource "ipam_ip_range" "my_team" {
-  name       = "my-team-prod"
-  range_size = 22
-  domain     = module.prod_network.domain.id
-  parent     = module.prod_network.networks["tenant"].cidr
-  labels     = { team = "my-team", env = "prod" }
-}
 ```
 
-See [`modules/ipam-network`](./modules/ipam-network) for all available variables and outputs.
-
-Or manage resources directly without the module:
-
-```hcl
-resource "ipam_routing_domain" "prod" {
-  name = "prod"
-}
-
-resource "ipam_ip_range" "root" {
-  name   = "prod-root"
-  cidr   = "10.0.0.0/8"
-  domain = ipam_routing_domain.prod.id
-}
-
-resource "ipam_ip_range" "gke_nodes" {
-  name       = "prod-gke-nodes"
-  range_size = 22
-  domain     = ipam_routing_domain.prod.id
-  parent     = ipam_ip_range.root.cidr
-  labels = {
-    env     = "prod"
-    purpose = "gke-nodes"
-  }
-}
-
-output "gke_nodes_cidr" {
-  value = ipam_ip_range.gke_nodes.cidr
-}
-```
-
-To read an existing range without allocating (cross-stack, by name):
-
-```hcl
-data "ipam_ip_range" "existing" {
-  name = "prod-gke-nodes"
-}
-```
-
-Or by ID when the range is managed in the same stack:
-
-```hcl
-data "ipam_ip_range" "existing" {
-  id = ipam_ip_range.gke_nodes.id
-}
-```
-
-To read utilization stats for a range:
-
-```hcl
-data "ipam_ip_range_stats" "tenant" {
-  id = module.prod_network.networks["tenant"].id
-}
-
-output "tenant_utilization_pct" {
-  value = data.ipam_ip_range_stats.tenant.utilization_pct
-}
-```
-
-See [`examples/sandbox-gcp-vpc`](./examples/sandbox-gcp-vpc) for a working example.
+For a full working example see [`examples/sandbox-network`](./examples/sandbox-network).
 
 ---
 
-## Authentication
+## Documentation
 
-The Terraform provider authenticates against the Cloud Run backend using Google identity tokens obtained from Application Default Credentials (ADC).
-
-**Local development** — run once:
-
-```bash
-gcloud auth application-default login
-```
-
-**CI/CD** — set the `IPAM_IDENTITY_TOKEN` environment variable to a valid Google identity token:
-
-```bash
-export IPAM_IDENTITY_TOKEN=$(gcloud auth print-identity-token \
-  --audiences="https://your-ipam-cloud-run-url")
-```
-
-**Private Cloud Run (production)** — the Cloud Run service should have `roles/run.invoker` granted to the caller's service account. The provider handles token retrieval automatically from the attached SA.
-
-**Provider configuration:**
-
-```hcl
-provider "ipam" {
-  url = "https://your-ipam-cloud-run-url"   # or set IPAM_URL env var
-}
-```
+- [Getting started guide](./docs/guides/getting-started.md) — authentication, provider setup, first allocation
+- [`modules/ipam-infra`](./modules/ipam-infra) — all backend module variables and outputs
+- [`modules/ipam-network`](./modules/ipam-network) — all network module variables and outputs
+- [Terraform provider registry](https://registry.terraform.io/providers/boozt-platform/ipam-autopilot/latest/docs) — provider resources and data sources
 
 ---
 
-## API
+## Contributing
 
-All endpoints are available under `/api/v1`:
-
-```
-POST   /api/v1/ranges              allocate a new IP range (auto or direct CIDR)
-GET    /api/v1/ranges              list all ranges; optional ?name= filter
-GET    /api/v1/ranges/:id          get a single range
-PUT    /api/v1/ranges/:id          update labels on an existing range (in-place)
-DELETE /api/v1/ranges/:id          release a range
-POST   /api/v1/ranges/import       bulk-import pre-existing CIDRs (idempotent)
-
-POST   /api/v1/domains             create a routing domain
-GET    /api/v1/domains             list all routing domains
-GET    /api/v1/domains/:id         get a single routing domain
-PUT    /api/v1/domains/:id         update a routing domain
-DELETE /api/v1/domains/:id         delete a routing domain
-
-GET    /api/v1/audit?limit=N       last N audit log events (default 100, max 1000)
-```
-
-Legacy paths (`/ranges`, `/domains`) are kept for backward compatibility.
-
----
-
-## Environment variables (backend)
-
-All variables use the `IPAM_` prefix, except OpenTelemetry standard variables.
-
-**Database**
-
-| Variable | Default | Description |
-|---|---|---|
-| `IPAM_DATABASE_USER` | | MySQL username |
-| `IPAM_DATABASE_PASSWORD` | | MySQL password (not used with Cloud SQL IAM auth) |
-| `IPAM_DATABASE_HOST` | | MySQL `host:port` or Unix socket path |
-| `IPAM_DATABASE_NAME` | | MySQL database name |
-| `IPAM_DATABASE_NET` | `tcp` | Network type (`tcp` or `unix`) |
-| `IPAM_DISABLE_DATABASE_MIGRATION` | `FALSE` | Set `TRUE` to skip auto-migration on startup |
-
-**Server**
-
-| Variable | Default | Description |
-|---|---|---|
-| `IPAM_PORT` | `8080` | HTTP listen port |
-| `IPAM_LOG_FORMAT` | `json` | Set `text` for human-readable logs |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | | OTLP gRPC endpoint for tracing (e.g. `jaeger:4317`) |
-
-**Features**
-
-| Variable | Default | Description |
-|---|---|---|
-| `IPAM_CAI_ORG_ID` | | GCP organisation ID for Cloud Asset Inventory integration |
-| `IPAM_CAI_DB_SYNC` | `FALSE` | Set `TRUE` to enable DB-backed CAI cache with background sync |
-| `IPAM_CAI_SYNC_INTERVAL` | `5m` | Sync interval when `IPAM_CAI_DB_SYNC=TRUE` (Go duration) |
-| `IPAM_DISABLE_BULK_IMPORT` | `FALSE` | Set `TRUE` to disable `POST /api/v1/ranges/import` |
-
-**Terraform provider**
-
-| Variable | Default | Description |
-|---|---|---|
-| `IPAM_URL` | | IPAM API base URL (alternative to `url` in provider config) |
-| `IPAM_IDENTITY_TOKEN` | | Identity token for Cloud Run auth; if unset, ADC is used automatically |
-
----
-
-## Cloud Asset Inventory integration
-
-When `IPAM_CAI_ORG_ID` is set, IPAM Autopilot discovers existing VPC subnets across your GCP organisation via Cloud Asset Inventory and merges them with IPAM allocations before running collision avoidance. This prevents double-allocation even for subnets not registered in IPAM.
-
-**VPC scoping** — Each routing domain has an optional list of VPCs. Only subnets belonging to those VPCs are considered, so allocations for `prod-vpc` are independent of `staging-vpc`.
-
-**VPC name format** — accepts both full resource URLs and short names:
-
-```
-https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-vpc
-my-vpc
-```
-
-**Two modes**
-
-| Mode | Config | Behaviour |
-|---|---|---|
-| Live (default) | `IPAM_CAI_ORG_ID` only | CAI API queried on every allocation; always up to date |
-| DB sync | `IPAM_CAI_ORG_ID` + `IPAM_CAI_DB_SYNC=TRUE` | Subnets cached in `cai_subnets` table, refreshed every `IPAM_CAI_SYNC_INTERVAL`; fast, no per-request CAI latency |
-
-**Required IAM** - the Cloud Run service account needs `roles/cloudasset.viewer` at the organisation level (granted automatically by `modules/ipam-infra` when `organization_id` is set).
-
----
-
-## Bulk import
-
-Use `POST /api/v1/ranges/import` to register pre-existing CIDRs without triggering auto-allocation. Recommended when adopting IPAM for a VPC that already has manually-assigned subnets.
-
-```bash
-curl -X POST https://YOUR_IPAM_URL/api/v1/ranges/import \
-  -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
-  -H "Content-Type: application/json" \
-  -d '[
-    {"name": "gke-nodes", "cidr": "10.1.0.0/22", "domain": "1", "labels": {"env": "prod"}},
-    {"name": "gke-pods",  "cidr": "10.2.0.0/16", "domain": "1"}
-  ]'
-```
-
-The endpoint is idempotent — ranges already present in the same domain are silently skipped. Returns `{ "imported": 2, "skipped": 0, "errors": [] }`.
-
-Set `IPAM_DISABLE_BULK_IMPORT=TRUE` to disable the endpoint in production.
-
----
-
-## Local development
-
-### Prerequisites
-
-- Docker + Docker Compose
-- Go 1.26
-- Terraform or OpenTofu
-
-Alternatively, open the repo in VS Code — it includes a [devcontainer](./.devcontainer) with all tools pre-installed.
-
-### Start the stack
-
-```bash
-docker compose up --build -d   # MySQL + API (localhost:8080) + Jaeger (localhost:16686)
-```
-
-### Common tasks
-
-```bash
-make test                # unit tests (container + provider)
-make test-integration    # integration tests via testcontainers (requires Docker)
-make lint                # golangci-lint
-make dev-apply           # build provider binary + tofu apply against docker-compose
-make dev-destroy         # tofu destroy local dev resources
-```
-
----
-
-## Subnet selection logic
-
-![IP Subnet selection logic](./img/flow.png "Sequence flow")
-
-Given a request for a `/24` within `10.0.0.0/8`, with `10.0.0.0/28` and `10.0.0.16/28` already allocated in IPAM, and `10.0.0.64/26` discovered via CAI — `10.0.0.0/24` would collide, so IPAM Autopilot allocates `10.0.1.0/24`.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for dev environment setup, testing, and commit conventions.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the `modules/ipam-infra` Terraform module to deploy the IPAM backend to GCP:
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.15.0"
 
   project_id      = "my-project"
   region          = "europe-west1"
@@ -64,7 +64,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.13"
+      version = "~> 1.15"
     }
   }
 }
@@ -74,7 +74,7 @@ provider "ipam" {
 }
 
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.15.0"
 
   domain = {
     name = "prod-vpc"

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ For a full working example see [`examples/sandbox-network`](./examples/sandbox-n
 
 ## Documentation
 
-- [Getting started guide](./docs/guides/getting-started.md) — authentication, provider setup, first allocation
-- [`modules/ipam-infra`](./modules/ipam-infra) — all backend module variables and outputs
-- [`modules/ipam-network`](./modules/ipam-network) — all network module variables and outputs
-- [Terraform provider registry](https://registry.terraform.io/providers/boozt-platform/ipam-autopilot/latest/docs) — provider resources and data sources
+- [Getting started guide](./docs/guides/getting-started.md): authentication, provider setup, first allocation
+- [`modules/ipam-infra`](./modules/ipam-infra): all backend module variables and outputs
+- [`modules/ipam-network`](./modules/ipam-network): all network module variables and outputs
+- [Terraform provider registry](https://registry.terraform.io/providers/boozt-platform/ipam-autopilot/latest/docs): provider resources and data sources
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -21,7 +21,7 @@ module "ipam" {
 }
 
 output "ipam_url" {
-  value = module.ipam.cloud_run_url
+  value = module.ipam.service_url
 }
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.15.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.13"
+      version = "~> 1.15"
     }
   }
 }

--- a/examples/sandbox-network/providers.tf
+++ b/examples/sandbox-network/providers.tf
@@ -15,11 +15,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.26"
+      version = "~> 1.15"
     }
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.13"
+      version = "~> 1.15"
     }
   }
 }

--- a/examples/sandbox-network/providers.tf
+++ b/examples/sandbox-network/providers.tf
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 1.15"
+      version = "~> 7.26"
     }
     ipam = {
       source  = "boozt-platform/ipam-autopilot"

--- a/modules/ipam-infra/README.md
+++ b/modules/ipam-infra/README.md
@@ -6,7 +6,7 @@ Deploys the IPAM Autopilot backend to GCP — Cloud Run service, Cloud SQL (MySQ
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.15.0"
 
   project_id = "my-project"
   region     = "europe-west1"

--- a/modules/ipam-network/README.md
+++ b/modules/ipam-network/README.md
@@ -6,7 +6,7 @@ Registers a VPC network and its top-level IP blocks in IPAM Autopilot. Creates a
 
 ```hcl
 module "prod_network" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-network?ref=v1.15.0"
 
   domain = "prod-vpc"
   labels = { env = "prod" }

--- a/modules/ipam-network/providers.tf
+++ b/modules/ipam-network/providers.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.13"
+      version = "~> 1.15"
     }
   }
 }

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -21,7 +21,7 @@ module "ipam" {
 }
 
 output "ipam_url" {
-  value = module.ipam.cloud_run_url
+  value = module.ipam.service_url
 }
 ```
 

--- a/provider/templates/guides/getting-started.md.tmpl
+++ b/provider/templates/guides/getting-started.md.tmpl
@@ -14,7 +14,7 @@ Use the `modules/ipam-infra` module from the [boozt-platform/ipam-autopilot](htt
 
 ```hcl
 module "ipam" {
-  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.13.1"
+  source = "github.com/boozt-platform/ipam-autopilot//modules/ipam-infra?ref=v1.15.0"
 
   project_id = "my-gcp-project"
   region     = "europe-west1"
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     ipam = {
       source  = "boozt-platform/ipam-autopilot"
-      version = "~> 1.13"
+      version = "~> 1.15"
     }
   }
 }


### PR DESCRIPTION
   ## Summary

   - Bumps all module source `?ref=` and provider version constraints to v1.15.0
   - Fixes `update-version` Makefile target: was replacing all `version = "~> X.Y"` constraints in files containing `boozt-platform/ipam-autopilot`, including unrelated providers like `hashicorp/google`; now scoped to the ipam-autopilot provider block only
   - Fixes `make docs` on macOS: replaces `sed -i` with `perl -pi -e` for BSD/GNU compatibility
   - Rewrites README to a concise project overview with quick start examples
   - Adds CONTRIBUTING.md with developer guide: repo layout, local dev setup, testing, commit
   conventions