### PR TITLE
fix: use user_managed replication for Secret Manager secret

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -170,6 +170,10 @@ Original source: https://github.com/GoogleCloudPlatform/professional-services/tr
 - Removed `ForceNew` from `labels` in `ipam_ip_range` provider resource - label changes now trigger an in-place update instead of destroy+recreate
 - Added `resourceUpdate` to Terraform provider - calls `PUT /ranges/:id` with the new labels map
 
+## Bug fixes
+
+- Fixed `google_secret_manager_secret` replication mode in `modules/ipam-infra` - changed from `auto {}` (global replication) to `user_managed` with a single replica in `var.region`; required for GCP organizations with `constraints/gcp.resourceLocations` org policy that restricts resource creation to specific regions
+
 ## Provider documentation
 
 - Added `provider/docs/` - OpenTofu registry-compatible documentation generated via `terraform-plugin-docs`; covers provider index, `ipam_ip_range` resource, `ipam_routing_domain` resource, `ipam_ip_range` data source, and a getting-started guide

--- a/modules/ipam-infra/main.tf
+++ b/modules/ipam-infra/main.tf
@@ -219,7 +219,11 @@ resource "google_secret_manager_secret" "db_default_password" {
   secret_id = "${var.database_instance_name}-setup-password"
 
   replication {
-    auto {}
+    user_managed {
+      replicas {
+        location = var.region
+      }
+    }
   }
 
   depends_on = [google_project_service.apis]


### PR DESCRIPTION
auto {} replication creates a global secret which violates constraints/gcp.resourceLocations org policy when restricted to specific regions. Switched to user_managed with a single replica in var.region.